### PR TITLE
Clean up logging defaults and reduce log noise

### DIFF
--- a/crates/pensieve-ingest/src/bin/jsonl.rs
+++ b/crates/pensieve-ingest/src/bin/jsonl.rs
@@ -33,6 +33,7 @@ use metrics::{counter, gauge};
 use pensieve_core::metrics::{init_metrics, start_metrics_server};
 use pensieve_ingest::{
     ClickHouseConfig, ClickHouseIndexer, DedupeIndex, SealedSegment, SegmentConfig, SegmentWriter,
+    logging::compact_error,
     source::{EventSource, JsonlConfig, JsonlSource},
 };
 use serde::{Deserialize, Serialize};
@@ -163,7 +164,7 @@ impl Progress {
 async fn main() -> Result<()> {
     // Initialize tracing
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive("info".parse().unwrap()))
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .init();
 
     let args = Args::parse();
@@ -322,7 +323,12 @@ async fn index_segments_mode(
                 );
             }
             Err(e) => {
-                tracing::error!("Failed to index segment {}: {}", segment_num, e);
+                tracing::error!(
+                    segment_number = segment_num,
+                    path = %segment_path.display(),
+                    error = %compact_error(&e),
+                    "failed to index segment"
+                );
                 errors += 1;
                 // Continue with next segment
             }
@@ -579,7 +585,11 @@ fn process(args: &Args, input: &Path, output: &Path) -> Result<Stats> {
                 // Mark as completed and save progress
                 progress.mark_completed(&file_path_str);
                 if let Err(e) = progress.save(&progress_file) {
-                    tracing::warn!("Failed to save progress: {}", e);
+                    tracing::warn!(
+                        path = %progress_file.display(),
+                        error = %compact_error(&e),
+                        "failed to save jsonl backfill progress"
+                    );
                 }
 
                 // Update metrics after each file (calculate adjusted valid_events on the fly)
@@ -592,7 +602,11 @@ fn process(args: &Args, input: &Path, output: &Path) -> Result<Stats> {
                 record_metrics(&metrics_stats, process_start.elapsed().as_secs_f64());
             }
             Err(e) => {
-                tracing::error!("Error processing {}: {}", file_path.display(), e);
+                tracing::error!(
+                    path = %file_path.display(),
+                    error = %compact_error(&e),
+                    "error processing jsonl file"
+                );
                 if !args.continue_on_error {
                     return Err(e.into());
                 }

--- a/crates/pensieve-ingest/src/bin/proto.rs
+++ b/crates/pensieve-ingest/src/bin/proto.rs
@@ -810,14 +810,13 @@ fn process_file_impl(
                 break;
             }
             Err(e) => {
-                let error = compact_error(&e);
-                tracing::warn!(error = %error, "protobuf decode failed");
+                tracing::warn!(error = %compact_error(&e), "protobuf decode failed");
                 stats.invalid_events += 1;
                 stats.proto_errors += 1;
                 if args.continue_on_error {
                     break;
                 } else {
-                    bail!("Protobuf decode error: {}", error);
+                    bail!("Protobuf decode error: {}", e);
                 }
             }
         };
@@ -834,7 +833,6 @@ fn process_file_impl(
                     (id_bytes, len)
                 }
                 Err(e) => {
-                    let error = compact_error(&e);
                     tracing::warn!(
                         event_id = %proto_event.id,
                         kind = proto_event.kind,
@@ -842,7 +840,7 @@ fn process_file_impl(
                         tag_count = proto_event.tags.len(),
                         content_len = proto_event.content.len(),
                         payload_bytes = proto_bytes,
-                        error = %error,
+                        error = %compact_error(&e),
                         "protobuf event failed notepack encoding"
                     );
                     stats.invalid_events += 1;
@@ -850,7 +848,7 @@ fn process_file_impl(
                     if args.continue_on_error {
                         continue;
                     } else {
-                        bail!("Notepack encoding error: {}", error);
+                        bail!("Notepack encoding error: {}", e);
                     }
                 }
             }
@@ -862,7 +860,6 @@ fn process_file_impl(
                     (id_bytes, len)
                 }
                 Err(e) => {
-                    let error = compact_error(&e);
                     tracing::warn!(
                         event_id = %proto_event.id,
                         kind = proto_event.kind,
@@ -870,7 +867,7 @@ fn process_file_impl(
                         tag_count = proto_event.tags.len(),
                         content_len = proto_event.content.len(),
                         payload_bytes = proto_bytes,
-                        error = %error,
+                        error = %compact_error(&e),
                         "protobuf event validation failed"
                     );
                     stats.invalid_events += 1;
@@ -878,7 +875,7 @@ fn process_file_impl(
                     if args.continue_on_error {
                         continue;
                     } else {
-                        bail!("Validation error: {}", error);
+                        bail!("Validation error: {}", e);
                     }
                 }
             }

--- a/crates/pensieve-ingest/src/bin/proto.rs
+++ b/crates/pensieve-ingest/src/bin/proto.rs
@@ -44,7 +44,7 @@ use pensieve_core::{
 };
 use pensieve_ingest::{
     ClickHouseConfig, ClickHouseIndexer, DedupeIndex, PackedEvent, SealedSegment, SegmentConfig,
-    SegmentWriter,
+    SegmentWriter, logging::compact_error,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -189,7 +189,7 @@ impl Progress {
 async fn main() -> Result<()> {
     // Initialize tracing
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive("info".parse().unwrap()))
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .init();
 
     let args = Args::parse();
@@ -399,7 +399,11 @@ async fn process_s3(args: &Args) -> Result<Stats> {
                 stats.compressed_proto_bytes += size;
             }
             Err(e) => {
-                tracing::error!("Failed to download {}: {}", key, e);
+                tracing::error!(
+                    object_key = %key,
+                    error = %compact_error(&e),
+                    "failed to download s3 object"
+                );
                 if args.continue_on_error {
                     continue;
                 } else {
@@ -424,14 +428,22 @@ async fn process_s3(args: &Args) -> Result<Stats> {
                 // Mark as completed and save progress
                 progress.mark_completed(key);
                 if let Err(e) = progress.save(&progress_file) {
-                    tracing::warn!("Failed to save progress: {}", e);
+                    tracing::warn!(
+                        path = %progress_file.display(),
+                        error = %compact_error(&e),
+                        "failed to save proto backfill progress"
+                    );
                 }
 
                 // Update metrics after each file
                 record_metrics(&stats, process_start.elapsed().as_secs_f64());
             }
             Err(e) => {
-                tracing::error!("Error processing {}: {}", key, e);
+                tracing::error!(
+                    object_key = %key,
+                    error = %compact_error(&e),
+                    "error processing s3 protobuf object"
+                );
                 if !args.continue_on_error {
                     // Clean up temp file before returning
                     let _ = fs::remove_file(&temp_path);
@@ -442,7 +454,11 @@ async fn process_s3(args: &Args) -> Result<Stats> {
 
         // Delete temp file
         if let Err(e) = fs::remove_file(&temp_path) {
-            tracing::warn!("Failed to delete temp file {}: {}", temp_path.display(), e);
+            tracing::warn!(
+                path = %temp_path.display(),
+                error = %compact_error(&e),
+                "failed to delete temp protobuf file"
+            );
         }
     }
 
@@ -601,7 +617,11 @@ fn process_local(args: &Args) -> Result<Stats> {
                 record_metrics(&stats, process_start.elapsed().as_secs_f64());
             }
             Err(e) => {
-                tracing::warn!("Error processing {}: {}", file_path.display(), e);
+                tracing::warn!(
+                    path = %file_path.display(),
+                    error = %compact_error(&e),
+                    "error processing protobuf file"
+                );
                 if !args.continue_on_error {
                     return Err(e);
                 }
@@ -790,13 +810,14 @@ fn process_file_impl(
                 break;
             }
             Err(e) => {
-                tracing::warn!("Protobuf decode error: {}", e);
+                let error = compact_error(&e);
+                tracing::warn!(error = %error, "protobuf decode failed");
                 stats.invalid_events += 1;
                 stats.proto_errors += 1;
                 if args.continue_on_error {
                     break;
                 } else {
-                    bail!("Protobuf decode error: {}", e);
+                    bail!("Protobuf decode error: {}", error);
                 }
             }
         };
@@ -813,13 +834,23 @@ fn process_file_impl(
                     (id_bytes, len)
                 }
                 Err(e) => {
-                    tracing::warn!("Notepack encoding error: {}", e);
+                    let error = compact_error(&e);
+                    tracing::warn!(
+                        event_id = %proto_event.id,
+                        kind = proto_event.kind,
+                        pubkey = %proto_event.pubkey,
+                        tag_count = proto_event.tags.len(),
+                        content_len = proto_event.content.len(),
+                        payload_bytes = proto_bytes,
+                        error = %error,
+                        "protobuf event failed notepack encoding"
+                    );
                     stats.invalid_events += 1;
                     stats.proto_errors += 1;
                     if args.continue_on_error {
                         continue;
                     } else {
-                        bail!("Notepack encoding error: {}", e);
+                        bail!("Notepack encoding error: {}", error);
                     }
                 }
             }
@@ -831,13 +862,23 @@ fn process_file_impl(
                     (id_bytes, len)
                 }
                 Err(e) => {
-                    tracing::warn!("Validation error: {}", e);
+                    let error = compact_error(&e);
+                    tracing::warn!(
+                        event_id = %proto_event.id,
+                        kind = proto_event.kind,
+                        pubkey = %proto_event.pubkey,
+                        tag_count = proto_event.tags.len(),
+                        content_len = proto_event.content.len(),
+                        payload_bytes = proto_bytes,
+                        error = %error,
+                        "protobuf event validation failed"
+                    );
                     stats.invalid_events += 1;
                     stats.validation_errors += 1;
                     if args.continue_on_error {
                         continue;
                     } else {
-                        bail!("Validation error: {}", e);
+                        bail!("Validation error: {}", error);
                     }
                 }
             }

--- a/crates/pensieve-ingest/src/bin/repair-dedupe.rs
+++ b/crates/pensieve-ingest/src/bin/repair-dedupe.rs
@@ -20,6 +20,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rocksdb::{DB, DBWithThreadMode, MultiThreaded, Options, WriteBatch};
 use std::path::PathBuf;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Debug)]
 #[command(name = "repair-dedupe")]
@@ -47,7 +48,9 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt().with_env_filter("info").init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
 
     let args = Args::parse();
 

--- a/crates/pensieve-ingest/src/lib.rs
+++ b/crates/pensieve-ingest/src/lib.rs
@@ -39,6 +39,7 @@
 //! and ClickHouse is a derived index.
 
 pub mod error;
+pub mod logging;
 pub mod pipeline;
 pub mod relay;
 pub mod source;

--- a/crates/pensieve-ingest/src/logging.rs
+++ b/crates/pensieve-ingest/src/logging.rs
@@ -10,7 +10,7 @@ const DEFAULT_LOG_VALUE_LIMIT: usize = 240;
 const NOTICE_LOG_VALUE_LIMIT: usize = 160;
 
 /// Compact an external/log-derived string into a single-line value.
-pub fn compact_log_value(value: &str) -> String {
+pub(crate) fn compact_log_value(value: &str) -> String {
     compact_log_value_with_limit(value, DEFAULT_LOG_VALUE_LIMIT)
 }
 

--- a/crates/pensieve-ingest/src/logging.rs
+++ b/crates/pensieve-ingest/src/logging.rs
@@ -1,0 +1,66 @@
+//! Logging helpers for compact, operationally useful messages.
+//!
+//! These helpers intentionally collapse whitespace and cap message length so
+//! logs don't dump giant event payloads, tag arrays, or multiline blobs into
+//! journald/Loki.
+
+use std::fmt::Display;
+
+const DEFAULT_LOG_VALUE_LIMIT: usize = 240;
+const NOTICE_LOG_VALUE_LIMIT: usize = 160;
+
+/// Compact an external/log-derived string into a single-line value.
+pub fn compact_log_value(value: &str) -> String {
+    compact_log_value_with_limit(value, DEFAULT_LOG_VALUE_LIMIT)
+}
+
+/// Compact a relay/server notice into a shorter single-line value.
+pub fn compact_notice(value: &str) -> String {
+    compact_log_value_with_limit(value, NOTICE_LOG_VALUE_LIMIT)
+}
+
+/// Compact an error into a single-line value with a bounded length.
+pub fn compact_error(err: impl Display) -> String {
+    compact_log_value(&err.to_string())
+}
+
+fn compact_log_value_with_limit(value: &str, max_chars: usize) -> String {
+    let collapsed = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_chars(&collapsed, max_chars)
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{truncated}…")
+    } else {
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_log_value_collapses_whitespace() {
+        assert_eq!(compact_log_value("hello\n  world\t!"), "hello world !");
+    }
+
+    #[test]
+    fn compact_log_value_truncates_long_strings() {
+        let input = "a".repeat(300);
+        let output = compact_log_value(&input);
+        assert_eq!(output.chars().count(), 241);
+        assert!(output.ends_with('…'));
+    }
+
+    #[test]
+    fn compact_notice_uses_shorter_limit() {
+        let input = "b".repeat(300);
+        let output = compact_notice(&input);
+        assert_eq!(output.chars().count(), 161);
+        assert!(output.ends_with('…'));
+    }
+}

--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -35,6 +35,7 @@ use pensieve_core::metrics::{init_metrics, start_metrics_server};
 use pensieve_ingest::{
     ClickHouseConfig, ClickHouseIndexer, DedupeIndex, NegentropySyncConfig, NegentropySyncer,
     RelayManager, RelayManagerConfig, SealedSegment, SegmentConfig, SegmentWriter, SyncStateDb,
+    logging::compact_error,
     pack_nostr_event,
     relay::normalize_relay_url,
     seed_from_clickhouse,
@@ -78,7 +79,7 @@ fn load_seeds_from_file(path: &std::path::Path) -> Result<Vec<String>> {
         if let Some(normalized) = normalize_relay_url(line).ok() {
             seeds.push(normalized);
         } else {
-            tracing::warn!("Skipping invalid/blocked relay URL in seed file: {}", line);
+            tracing::warn!(seed_entry = %line, "skipping invalid or blocked relay URL from seed file");
         }
     }
     Ok(seeds)
@@ -137,6 +138,13 @@ struct Args {
     /// Metrics HTTP server port (0 to disable)
     #[arg(long, default_value = "9091")]
     metrics_port: u16,
+
+    /// Emit periodic operational progress lines at INFO instead of DEBUG.
+    ///
+    /// This is useful for live tuning when you want throughput/checkpoint
+    /// progress without broadly increasing log verbosity via RUST_LOG.
+    #[arg(long)]
+    verbose_ops: bool,
 
     /// SQLite database path for relay quality tracking
     #[arg(long, default_value = "./data/relay-stats.db")]
@@ -225,11 +233,7 @@ async fn main() -> Result<()> {
 
     // Initialize tracing
     tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::from_default_env()
-                .add_directive("info".parse().unwrap())
-                .add_directive("pensieve_ingest=debug".parse().unwrap()),
-        )
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .init();
 
     let args = Args::parse();
@@ -389,40 +393,28 @@ async fn main() -> Result<()> {
         ..Default::default()
     };
 
-    if args.tor_proxy.is_some() {
-        tracing::info!("Tor proxy enabled - .onion relays will be routed through proxy");
+    if let Some(proxy_addr) = args.tor_proxy {
+        tracing::info!(tor_proxy = %proxy_addr, "tor proxy enabled for .onion relays");
     }
 
-    tracing::info!("Configuration:");
-    tracing::info!("  RocksDB: {}", args.rocksdb_path.display());
-    tracing::info!("  Relay DB: {}", args.relay_db_path.display());
-    tracing::info!("  Output: {}", args.output_dir.display());
+    let catchup = match relay_config.since_timestamp {
+        Some(ts) => format!("since {ts}"),
+        None => "disabled".to_string(),
+    };
     tracing::info!(
-        "  ClickHouse: {}",
-        args.clickhouse_url.as_deref().unwrap_or("disabled")
-    );
-    tracing::info!("  Seed relays: {}", relay_config.seed_relays.len());
-    tracing::info!("  Discovery: {}", relay_config.discovery_enabled);
-    tracing::info!("  Max relays: {}", relay_config.max_relays);
-    tracing::info!(
-        "  Optimization interval: {}s",
-        relay_config.optimization_interval.as_secs()
-    );
-    tracing::info!(
-        "  Catch-up: {}",
-        match relay_config.since_timestamp {
-            Some(ts) => format!("enabled (since {}) - WARNING: may reduce throughput", ts),
-            None => "disabled (default)".to_string(),
-        }
-    );
-    tracing::info!("  Checkpoint interval: {}s", args.checkpoint_interval_secs);
-    tracing::info!(
-        "  Negentropy sync: {}",
-        if args.negentropy {
-            "enabled"
-        } else {
-            "disabled"
-        }
+        rocksdb_path = %args.rocksdb_path.display(),
+        relay_db_path = %args.relay_db_path.display(),
+        output_dir = %args.output_dir.display(),
+        clickhouse = %args.clickhouse_url.as_deref().unwrap_or("disabled"),
+        seed_relays = relay_config.seed_relays.len(),
+        discovery = relay_config.discovery_enabled,
+        max_relays = relay_config.max_relays,
+        optimization_interval_secs = relay_config.optimization_interval.as_secs(),
+        catchup = %catchup,
+        checkpoint_interval_secs = args.checkpoint_interval_secs,
+        verbose_ops = args.verbose_ops,
+        negentropy = args.negentropy,
+        "ingest configuration"
     );
 
     // Initialize negentropy sync (if enabled)
@@ -523,14 +515,12 @@ async fn main() -> Result<()> {
         };
 
         tracing::info!(
-            "  Negentropy interval: {}s",
-            negentropy_config.interval.as_secs()
+            relay_count = negentropy_config.relays.len(),
+            interval_secs = negentropy_config.interval.as_secs(),
+            lookback_days = args.negentropy_lookback_days,
+            "negentropy configuration"
         );
-        tracing::info!(
-            "  Negentropy lookback: {} days",
-            args.negentropy_lookback_days
-        );
-        tracing::info!("  Negentropy relays: {:?}", negentropy_config.relays);
+        tracing::debug!(relays = ?negentropy_config.relays, "negentropy relays");
 
         Some(Arc::new(NegentropySyncer::new(
             negentropy_config,
@@ -606,6 +596,7 @@ async fn main() -> Result<()> {
     let rate_events_received = Arc::clone(&events_received);
     let rate_events_processed = Arc::clone(&events_processed);
     let rate_events_deduplicated = Arc::clone(&events_deduplicated);
+    let rate_verbose_ops = args.verbose_ops;
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(5));
         interval.tick().await; // Skip first immediate tick
@@ -658,13 +649,23 @@ async fn main() -> Result<()> {
 
             // Log throughput periodically (every 5 seconds)
             if curr_received > 0 {
-                tracing::debug!(
-                    "Throughput: {:.0} received/s, {:.0} processed/s, {:.0} deduped/s ({:.1}% duplicates)",
-                    received_rate,
-                    processed_rate,
-                    deduplicated_rate,
-                    dedupe_ratio * 100.0
-                );
+                if rate_verbose_ops {
+                    tracing::info!(
+                        "Throughput: {:.0} received/s, {:.0} processed/s, {:.0} deduped/s ({:.1}% duplicates)",
+                        received_rate,
+                        processed_rate,
+                        deduplicated_rate,
+                        dedupe_ratio * 100.0
+                    );
+                } else {
+                    tracing::debug!(
+                        "Throughput: {:.0} received/s, {:.0} processed/s, {:.0} deduped/s ({:.1}% duplicates)",
+                        received_rate,
+                        processed_rate,
+                        deduplicated_rate,
+                        dedupe_ratio * 100.0
+                    );
+                }
             }
         }
 
@@ -676,6 +677,7 @@ async fn main() -> Result<()> {
     let checkpoint_relay_manager = Arc::clone(&relay_manager);
     let checkpoint_max_created_at = Arc::clone(&max_created_at);
     let checkpoint_interval = args.checkpoint_interval_secs;
+    let checkpoint_verbose_ops = args.verbose_ops;
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(checkpoint_interval));
         interval.tick().await; // Skip first immediate tick
@@ -691,9 +693,13 @@ async fn main() -> Result<()> {
             let max_ts = checkpoint_max_created_at.load(Ordering::Relaxed);
             if max_ts > 0 {
                 if let Err(e) = checkpoint_relay_manager.update_last_archived_timestamp(max_ts) {
-                    tracing::warn!("Failed to update checkpoint: {}", e);
+                    tracing::warn!(error = %compact_error(&e), "failed to update checkpoint");
                 } else {
-                    tracing::debug!("Updated checkpoint to {}", max_ts);
+                    if checkpoint_verbose_ops {
+                        tracing::info!(checkpoint = max_ts, "updated checkpoint");
+                    } else {
+                        tracing::debug!(checkpoint = max_ts, "updated checkpoint");
+                    }
                     gauge!("ingest_checkpoint_timestamp").set(max_ts as f64);
                 }
             }
@@ -731,7 +737,15 @@ async fn main() -> Result<()> {
                     let is_novel = match negentropy_dedupe.check_and_mark_pending(event_id) {
                         Ok(novel) => novel,
                         Err(e) => {
-                            tracing::warn!("Negentropy dedupe check error: {}", e);
+                            tracing::warn!(
+                                event_id = %event.id,
+                                kind = event.kind.as_u16(),
+                                pubkey = %event.pubkey,
+                                tag_count = event.tags.len(),
+                                content_len = event.content.len(),
+                                error = %compact_error(&e),
+                                "negentropy dedupe check failed"
+                            );
                             false
                         }
                     };
@@ -741,16 +755,33 @@ async fn main() -> Result<()> {
                         let packed = match pack_nostr_event(event) {
                             Ok(p) => p,
                             Err(e) => {
-                                tracing::debug!("Failed to pack negentropy event: {}", e);
+                                let error = compact_error(&e);
+                                tracing::debug!(
+                                    event_id = %event.id,
+                                    kind = event.kind.as_u16(),
+                                    pubkey = %event.pubkey,
+                                    tag_count = event.tags.len(),
+                                    content_len = event.content.len(),
+                                    error = %error,
+                                    "failed to pack negentropy event"
+                                );
                                 // Return error so event is NOT recorded in sync state
                                 // and will be re-fetched on next sync cycle
-                                return Err(pensieve_ingest::Error::Notepack(e.to_string()));
+                                return Err(pensieve_ingest::Error::Notepack(error));
                             }
                         };
 
                         // Write to segment - must succeed for event to be recorded in sync state
                         if let Err(e) = negentropy_segment_writer.write(packed) {
-                            tracing::error!("Failed to write negentropy event: {}", e);
+                            tracing::error!(
+                                event_id = %event.id,
+                                kind = event.kind.as_u16(),
+                                pubkey = %event.pubkey,
+                                tag_count = event.tags.len(),
+                                content_len = event.content.len(),
+                                error = %compact_error(&e),
+                                "failed to write negentropy event"
+                            );
                             // Return error so event is NOT recorded in sync state
                             // and will be re-fetched on next sync cycle
                             return Err(e);
@@ -777,7 +808,7 @@ async fn main() -> Result<()> {
                 })
                 .await
             {
-                tracing::error!("Negentropy sync task failed: {}", e);
+                tracing::error!(error = %compact_error(&e), "negentropy sync task failed");
             }
 
             tracing::debug!("Negentropy sync task stopped");
@@ -808,7 +839,16 @@ async fn main() -> Result<()> {
             let is_novel = match dedupe.check_and_mark_pending(event_id) {
                 Ok(novel) => novel,
                 Err(e) => {
-                    tracing::warn!("Dedupe check error: {}", e);
+                    tracing::warn!(
+                        relay_url = %relay_url,
+                        event_id = %event.id,
+                        kind = event.kind.as_u16(),
+                        pubkey = %event.pubkey,
+                        tag_count = event.tags.len(),
+                        content_len = event.content.len(),
+                        error = %compact_error(&e),
+                        "dedupe check failed for live event"
+                    );
                     false // Treat as duplicate on error
                 }
             };
@@ -822,7 +862,16 @@ async fn main() -> Result<()> {
                     Ok(packed) => {
                         // Write to segment
                         if let Err(e) = segment_writer.write(packed) {
-                            tracing::error!("Failed to write event: {}", e);
+                            tracing::error!(
+                                relay_url = %relay_url,
+                                event_id = %event.id,
+                                kind = event.kind.as_u16(),
+                                pubkey = %event.pubkey,
+                                tag_count = event.tags.len(),
+                                content_len = event.content.len(),
+                                error = %compact_error(&e),
+                                "failed to write live event"
+                            );
                             // Continue processing despite write errors
                         } else {
                             handler_events_processed.fetch_add(1, Ordering::Relaxed);
@@ -842,7 +891,16 @@ async fn main() -> Result<()> {
                         }
                     }
                     Err(e) => {
-                        tracing::debug!("Failed to pack event: {}", e);
+                        tracing::debug!(
+                            relay_url = %relay_url,
+                            event_id = %event.id,
+                            kind = event.kind.as_u16(),
+                            pubkey = %event.pubkey,
+                            tag_count = event.tags.len(),
+                            content_len = event.content.len(),
+                            error = %compact_error(&e),
+                            "failed to pack live event"
+                        );
                     }
                 }
             } else {
@@ -875,7 +933,7 @@ async fn main() -> Result<()> {
     // Flush negentropy sync state
     if let Some(ref syncer) = negentropy_syncer {
         if let Err(e) = syncer.sync_state().flush() {
-            tracing::warn!("Failed to flush negentropy sync state: {}", e);
+            tracing::warn!(error = %compact_error(&e), "failed to flush negentropy sync state");
         } else {
             tracing::info!(
                 "Negentropy sync state flushed: ~{} items",
@@ -901,7 +959,7 @@ async fn main() -> Result<()> {
 
     // Flush relay manager stats
     if let Err(e) = relay_manager.flush() {
-        tracing::warn!("Failed to flush relay stats: {}", e);
+        tracing::warn!(error = %compact_error(&e), "failed to flush relay stats");
     }
 
     // Save final checkpoint
@@ -909,7 +967,7 @@ async fn main() -> Result<()> {
     if final_checkpoint > 0 {
         match relay_manager.update_last_archived_timestamp(final_checkpoint) {
             Ok(()) => tracing::info!("Saved final checkpoint: {}", final_checkpoint),
-            Err(e) => tracing::warn!("Failed to save final checkpoint: {}", e),
+            Err(e) => tracing::warn!(error = %compact_error(&e), "failed to save final checkpoint"),
         }
     }
 

--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -245,7 +245,7 @@ async fn main() -> Result<()> {
         let metrics_handle = init_metrics();
         start_metrics_server(args.metrics_port, metrics_handle).await?;
         gauge!("ingestion_running").set(1.0);
-        tracing::info!("Metrics server listening on port {}", args.metrics_port);
+        tracing::info!(port = args.metrics_port, "metrics server listening");
     }
 
     // Set up graceful shutdown
@@ -277,30 +277,30 @@ async fn main() -> Result<()> {
     // Load seed relays (tier=seed, protected from eviction)
     // Priority: CLI args > seed file > hardcoded defaults
     let seed_relays = if let Some(relays) = args.seed_relays.clone() {
-        tracing::info!("Using {} seed relays from CLI arguments", relays.len());
+        tracing::info!(
+            relay_count = relays.len(),
+            "using seed relays from CLI arguments"
+        );
         relays
     } else if args.seed_file.exists() {
         match load_seeds_from_file(&args.seed_file) {
             Ok(relays) if !relays.is_empty() => {
                 tracing::info!(
-                    "Loaded {} seed relays from file: {}",
-                    relays.len(),
-                    args.seed_file.display()
+                    relay_count = relays.len(),
+                    path = %args.seed_file.display(),
+                    "loaded seed relays from file"
                 );
                 relays
             }
             Ok(_) => {
-                tracing::warn!(
-                    "Seed file {} is empty, using defaults",
-                    args.seed_file.display()
-                );
+                tracing::warn!(path = %args.seed_file.display(), "seed file is empty, using defaults");
                 default_seed_relays()
             }
             Err(e) => {
                 tracing::warn!(
-                    "Failed to load seed file {}: {}. Using defaults.",
-                    args.seed_file.display(),
-                    e
+                    path = %args.seed_file.display(),
+                    error = %compact_error(&e),
+                    "failed to load seed file, using defaults"
                 );
                 default_seed_relays()
             }
@@ -312,23 +312,28 @@ async fn main() -> Result<()> {
 
     // Register seeds with tier=seed (protected, score floor 0.5)
     relay_manager.register_seed_relays(&seed_relays)?;
-    tracing::info!("Registered {} seed relays (tier=seed)", seed_relays.len());
+    tracing::info!(
+        relay_count = seed_relays.len(),
+        tier = "seed",
+        "registered seed relays"
+    );
 
     // Import discovered relays from JSON if provided (tier=discovered, can be swapped)
     if let Some(json_path) = &args.import_discovered_json {
         match relay_manager.import_from_json(json_path) {
             Ok(count) => {
                 tracing::info!(
-                    "Imported {} discovered relays from JSON: {} (tier=discovered)",
-                    count,
-                    json_path.display()
+                    relay_count = count,
+                    path = %json_path.display(),
+                    tier = "discovered",
+                    "imported discovered relays from JSON"
                 );
             }
             Err(e) => {
                 tracing::warn!(
-                    "Failed to import discovered relays from {}: {}",
-                    json_path.display(),
-                    e
+                    path = %json_path.display(),
+                    error = %compact_error(&e),
+                    "failed to import discovered relays from JSON"
                 );
             }
         }
@@ -350,19 +355,19 @@ async fn main() -> Result<()> {
                 let clamped = checkpoint.min(now_secs);
                 if clamped < checkpoint {
                     tracing::warn!(
-                        "Checkpoint {} was in the future, clamped to current time {}",
-                        checkpoint,
-                        clamped
+                        checkpoint = checkpoint,
+                        clamped = clamped,
+                        "checkpoint was in the future and was clamped"
                     );
                 }
 
                 // Apply buffer to handle clock skew and relay propagation delay
                 let buffered = clamped.saturating_sub(args.catchup_buffer_secs);
                 tracing::info!(
-                    "Loaded checkpoint: {} (buffered to {} with {}s buffer)",
-                    clamped,
-                    buffered,
-                    args.catchup_buffer_secs
+                    checkpoint = clamped,
+                    buffered_checkpoint = buffered,
+                    buffer_secs = args.catchup_buffer_secs,
+                    "loaded checkpoint"
                 );
                 Some(buffered)
             }
@@ -374,8 +379,8 @@ async fn main() -> Result<()> {
             }
             Err(e) => {
                 tracing::warn!(
-                    "Failed to load checkpoint: {} - starting without catch-up",
-                    e
+                    error = %compact_error(&e),
+                    "failed to load checkpoint, starting without catch-up"
                 );
                 None
             }
@@ -422,32 +427,32 @@ async fn main() -> Result<()> {
         // Load trusted relays for negentropy sync
         let negentropy_relays = if let Some(ref relays) = args.negentropy_relays {
             tracing::info!(
-                "Using {} negentropy relays from CLI arguments",
-                relays.len()
+                relay_count = relays.len(),
+                "using negentropy relays from CLI arguments"
             );
             relays.clone()
         } else if let Some(ref file_path) = args.negentropy_relays_file {
             match load_seeds_from_file(file_path) {
                 Ok(relays) if !relays.is_empty() => {
                     tracing::info!(
-                        "Loaded {} negentropy relays from file: {}",
-                        relays.len(),
-                        file_path.display()
+                        relay_count = relays.len(),
+                        path = %file_path.display(),
+                        "loaded negentropy relays from file"
                     );
                     relays
                 }
                 Ok(_) => {
                     tracing::warn!(
-                        "Negentropy relays file {} is empty, using defaults",
-                        file_path.display()
+                        path = %file_path.display(),
+                        "negentropy relays file is empty, using defaults"
                     );
                     NegentropySyncConfig::default().relays
                 }
                 Err(e) => {
                     tracing::warn!(
-                        "Failed to load negentropy relays file {}: {}. Using defaults.",
-                        file_path.display(),
-                        e
+                        path = %file_path.display(),
+                        error = %compact_error(&e),
+                        "failed to load negentropy relays file, using defaults"
                     );
                     NegentropySyncConfig::default().relays
                 }
@@ -468,16 +473,16 @@ async fn main() -> Result<()> {
         )?);
 
         tracing::info!(
-            "Negentropy sync state opened: ~{} items",
-            sync_state.approximate_count().unwrap_or(0)
+            approximate_items = sync_state.approximate_count().unwrap_or(0),
+            "negentropy sync state opened"
         );
 
         // Seed from ClickHouse if sync state is empty and ClickHouse is available
         if sync_state.is_empty().unwrap_or(true) {
             if let Some(ref ch_url) = args.clickhouse_url {
                 tracing::info!(
-                    "Sync state is empty, seeding from ClickHouse (lookback: {} days)",
-                    args.negentropy_lookback_days
+                    lookback_days = args.negentropy_lookback_days,
+                    "sync state is empty, seeding from ClickHouse"
                 );
                 match seed_from_clickhouse(
                     &sync_state,
@@ -488,13 +493,12 @@ async fn main() -> Result<()> {
                 .await
                 {
                     Ok(count) => {
-                        tracing::info!("Seeded {} events into sync state from ClickHouse", count);
+                        tracing::info!(event_count = count, "seeded sync state from ClickHouse");
                     }
                     Err(e) => {
                         tracing::warn!(
-                            "Failed to seed sync state from ClickHouse: {}. \
-                             First negentropy sync may request more events than necessary.",
-                            e
+                            error = %compact_error(&e),
+                            "failed to seed sync state from ClickHouse; first negentropy sync may request more events than necessary"
                         );
                     }
                 }
@@ -596,7 +600,7 @@ async fn main() -> Result<()> {
     let rate_events_received = Arc::clone(&events_received);
     let rate_events_processed = Arc::clone(&events_processed);
     let rate_events_deduplicated = Arc::clone(&events_deduplicated);
-    let rate_verbose_ops = args.verbose_ops;
+    let verbose_ops = args.verbose_ops;
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(5));
         interval.tick().await; // Skip first immediate tick
@@ -649,21 +653,21 @@ async fn main() -> Result<()> {
 
             // Log throughput periodically (every 5 seconds)
             if curr_received > 0 {
-                if rate_verbose_ops {
+                if verbose_ops {
                     tracing::info!(
-                        "Throughput: {:.0} received/s, {:.0} processed/s, {:.0} deduped/s ({:.1}% duplicates)",
-                        received_rate,
-                        processed_rate,
-                        deduplicated_rate,
-                        dedupe_ratio * 100.0
+                        received_per_sec = received_rate,
+                        processed_per_sec = processed_rate,
+                        deduplicated_per_sec = deduplicated_rate,
+                        duplicate_pct = dedupe_ratio * 100.0,
+                        "throughput"
                     );
                 } else {
                     tracing::debug!(
-                        "Throughput: {:.0} received/s, {:.0} processed/s, {:.0} deduped/s ({:.1}% duplicates)",
-                        received_rate,
-                        processed_rate,
-                        deduplicated_rate,
-                        dedupe_ratio * 100.0
+                        received_per_sec = received_rate,
+                        processed_per_sec = processed_rate,
+                        deduplicated_per_sec = deduplicated_rate,
+                        duplicate_pct = dedupe_ratio * 100.0,
+                        "throughput"
                     );
                 }
             }
@@ -677,7 +681,6 @@ async fn main() -> Result<()> {
     let checkpoint_relay_manager = Arc::clone(&relay_manager);
     let checkpoint_max_created_at = Arc::clone(&max_created_at);
     let checkpoint_interval = args.checkpoint_interval_secs;
-    let checkpoint_verbose_ops = args.verbose_ops;
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(checkpoint_interval));
         interval.tick().await; // Skip first immediate tick
@@ -695,7 +698,7 @@ async fn main() -> Result<()> {
                 if let Err(e) = checkpoint_relay_manager.update_last_archived_timestamp(max_ts) {
                     tracing::warn!(error = %compact_error(&e), "failed to update checkpoint");
                 } else {
-                    if checkpoint_verbose_ops {
+                    if verbose_ops {
                         tracing::info!(checkpoint = max_ts, "updated checkpoint");
                     } else {
                         tracing::debug!(checkpoint = max_ts, "updated checkpoint");
@@ -755,19 +758,18 @@ async fn main() -> Result<()> {
                         let packed = match pack_nostr_event(event) {
                             Ok(p) => p,
                             Err(e) => {
-                                let error = compact_error(&e);
                                 tracing::debug!(
                                     event_id = %event.id,
                                     kind = event.kind.as_u16(),
                                     pubkey = %event.pubkey,
                                     tag_count = event.tags.len(),
                                     content_len = event.content.len(),
-                                    error = %error,
+                                    error = %compact_error(&e),
                                     "failed to pack negentropy event"
                                 );
                                 // Return error so event is NOT recorded in sync state
                                 // and will be re-fetched on next sync cycle
-                                return Err(pensieve_ingest::Error::Notepack(error));
+                                return Err(pensieve_ingest::Error::Notepack(e.to_string()));
                             }
                         };
 
@@ -936,8 +938,8 @@ async fn main() -> Result<()> {
             tracing::warn!(error = %compact_error(&e), "failed to flush negentropy sync state");
         } else {
             tracing::info!(
-                "Negentropy sync state flushed: ~{} items",
-                syncer.sync_state().approximate_count().unwrap_or(0)
+                approximate_items = syncer.sync_state().approximate_count().unwrap_or(0),
+                "negentropy sync state flushed"
             );
         }
     }
@@ -945,9 +947,9 @@ async fn main() -> Result<()> {
     // Seal final segment
     if let Some(sealed) = segment_writer.seal()? {
         tracing::info!(
-            "Sealed final segment {}: {} events",
-            sealed.segment_number,
-            sealed.event_count
+            segment_number = sealed.segment_number,
+            event_count = sealed.event_count,
+            "sealed final segment"
         );
 
         // Mark as archived
@@ -966,7 +968,7 @@ async fn main() -> Result<()> {
     let final_checkpoint = max_created_at.load(Ordering::Relaxed);
     if final_checkpoint > 0 {
         match relay_manager.update_last_archived_timestamp(final_checkpoint) {
-            Ok(()) => tracing::info!("Saved final checkpoint: {}", final_checkpoint),
+            Ok(()) => tracing::info!(checkpoint = final_checkpoint, "saved final checkpoint"),
             Err(e) => tracing::warn!(error = %compact_error(&e), "failed to save final checkpoint"),
         }
     }
@@ -976,7 +978,7 @@ async fn main() -> Result<()> {
         tracing::info!("Waiting for ClickHouse indexer to finish...");
         drop(segment_writer);
         if let Err(e) = handle.join() {
-            tracing::warn!("ClickHouse indexer thread panicked: {:?}", e);
+            tracing::warn!(panic = ?e, "ClickHouse indexer thread panicked");
         }
     }
 
@@ -992,29 +994,24 @@ async fn main() -> Result<()> {
     let final_deduplicated = events_deduplicated.load(Ordering::Relaxed);
 
     // Print summary
-    tracing::info!("═══════════════════════════════════════════════════════");
-    tracing::info!("SHUTDOWN COMPLETE");
-    tracing::info!("═══════════════════════════════════════════════════════");
-    tracing::info!("Events received:      {}", final_received);
-    tracing::info!("Events processed:     {}", final_processed);
-    tracing::info!("Events deduplicated:  {}", final_deduplicated);
     tracing::info!(
-        "Relays connected:     {}",
-        stats.source_metadata.relays_connected.unwrap_or(0)
-    );
-    tracing::info!(
-        "Relays discovered:    {}",
-        stats.source_metadata.relays_discovered.unwrap_or(0)
+        events_received = final_received,
+        events_processed = final_processed,
+        events_deduplicated = final_deduplicated,
+        relays_connected = stats.source_metadata.relays_connected.unwrap_or(0),
+        relays_discovered = stats.source_metadata.relays_discovered.unwrap_or(0),
+        "shutdown complete"
     );
     if let Some(rs) = relay_stats {
-        tracing::info!("───────────────────────────────────────────────────────");
-        tracing::info!("Relay Manager Stats:");
-        tracing::info!("  Total relays tracked:  {}", rs.total_relays);
-        tracing::info!("  Active relays:         {}", rs.active_relays);
-        tracing::info!("  Blocked relays:        {}", rs.blocked_relays);
-        tracing::info!("  Seed relays:           {}", rs.seed_relays);
-        tracing::info!("  Discovered relays:     {}", rs.discovered_relays);
-        tracing::info!("  Avg quality score:     {:.3}", rs.avg_score);
+        tracing::info!(
+            total_relays = rs.total_relays,
+            active_relays = rs.active_relays,
+            blocked_relays = rs.blocked_relays,
+            seed_relays = rs.seed_relays,
+            discovered_relays = rs.discovered_relays,
+            avg_quality_score = rs.avg_score,
+            "relay manager summary"
+        );
     }
 
     Ok(())
@@ -1030,7 +1027,7 @@ type PipelineComponents = (
 /// Initialize pipeline components.
 fn init_pipeline(args: &Args) -> Result<PipelineComponents> {
     // Initialize dedupe index
-    tracing::info!("Opening dedupe index at {}", args.rocksdb_path.display());
+    tracing::info!(path = %args.rocksdb_path.display(), "opening dedupe index");
     let dedupe = Arc::new(
         DedupeIndex::open(&args.rocksdb_path)
             .with_context(|| format!("Failed to open dedupe index at {:?}", args.rocksdb_path))?,
@@ -1038,8 +1035,8 @@ fn init_pipeline(args: &Args) -> Result<PipelineComponents> {
 
     let dedupe_stats = dedupe.stats();
     tracing::info!(
-        "Dedupe index opened: ~{} keys",
-        dedupe_stats.approximate_keys
+        approximate_keys = dedupe_stats.approximate_keys,
+        "dedupe index opened"
     );
 
     // Set up ClickHouse channel (optional)
@@ -1059,10 +1056,10 @@ fn init_pipeline(args: &Args) -> Result<PipelineComponents> {
     };
 
     tracing::info!(
-        "Segment writer: output={}, max_size={}, compress={}",
-        args.output_dir.display(),
-        args.segment_size,
-        !args.no_compress
+        output_dir = %args.output_dir.display(),
+        max_segment_size = args.segment_size,
+        compress = !args.no_compress,
+        "segment writer configured"
     );
 
     let segment_writer = Arc::new(
@@ -1073,7 +1070,7 @@ fn init_pipeline(args: &Args) -> Result<PipelineComponents> {
     // Initialize ClickHouse indexer (optional)
     let indexer_handle =
         if let (Some(ch_url), Some(receiver)) = (&args.clickhouse_url, sealed_receiver) {
-            tracing::info!("Starting ClickHouse indexer for {}", ch_url);
+            tracing::info!(url = %ch_url, "starting ClickHouse indexer");
             let ch_config = ClickHouseConfig {
                 url: ch_url.clone(),
                 database: args.clickhouse_db.clone(),

--- a/crates/pensieve-ingest/src/pipeline/clickhouse.rs
+++ b/crates/pensieve-ingest/src/pipeline/clickhouse.rs
@@ -17,6 +17,7 @@
 //! any partially-indexed segment.
 
 use super::segment::SealedSegment;
+use crate::logging::compact_error;
 use crate::{Error, Result};
 use clickhouse::{Client, Row};
 use crossbeam_channel::Receiver;
@@ -236,7 +237,7 @@ impl ClickHouseIndexer {
             match Self::parse_notepack(&data) {
                 Ok(row) => events.push(row),
                 Err(e) => {
-                    tracing::warn!("Failed to parse event: {}", e);
+                    tracing::warn!(error = %compact_error(&e), "failed to parse archived event for clickhouse");
                     // Continue with next event
                 }
             }

--- a/crates/pensieve-ingest/src/pipeline/segment.rs
+++ b/crates/pensieve-ingest/src/pipeline/segment.rs
@@ -21,6 +21,7 @@
 //! 3. Notify ClickHouse indexer via callback
 //! 4. Start a new segment
 
+use crate::logging::compact_error;
 use crate::{Error, Result};
 
 use chrono::{DateTime, Utc};
@@ -375,7 +376,11 @@ impl SegmentWriter {
                     Ok(compressed_bytes) => {
                         // Remove the uncompressed file
                         if let Err(e) = fs::remove_file(&path) {
-                            tracing::warn!("Failed to remove uncompressed segment: {}", e);
+                            tracing::warn!(
+                                path = %path.display(),
+                                error = %compact_error(&e),
+                                "failed to remove uncompressed segment"
+                            );
                         }
 
                         tracing::info!(
@@ -399,18 +404,23 @@ impl SegmentWriter {
                                 ..sealed_for_notify
                             };
                             if let Err(e) = sender.send(compressed_sealed) {
-                                tracing::warn!("Failed to send sealed segment notification: {}", e);
+                                tracing::warn!(error = %compact_error(&e), "failed to send sealed segment notification");
                             }
                         }
                     }
                     Err(e) => {
-                        tracing::error!("Failed to compress segment {}: {}", segment_number, e);
+                        tracing::error!(
+                            segment_number,
+                            path = %path.display(),
+                            error = %compact_error(&e),
+                            "failed to compress segment"
+                        );
                         // Still notify indexer with uncompressed segment on error
                         total_compressed_bytes.fetch_add(size_bytes, Ordering::Relaxed);
                         if let Some(sender) = sender
                             && let Err(e) = sender.send(sealed_for_notify)
                         {
-                            tracing::warn!("Failed to send sealed segment notification: {}", e);
+                            tracing::warn!(error = %compact_error(&e), "failed to send sealed segment notification");
                         }
                     }
                 }
@@ -432,7 +442,7 @@ impl SegmentWriter {
             if let Some(sender) = &self.sealed_sender
                 && let Err(e) = sender.send(sealed.clone())
             {
-                tracing::warn!("Failed to send sealed segment notification: {}", e);
+                tracing::warn!(error = %compact_error(&e), "failed to send sealed segment notification");
             }
         }
 
@@ -495,7 +505,7 @@ impl Drop for SegmentWriter {
     fn drop(&mut self) {
         // Seal any remaining segment on drop
         if let Err(e) = self.seal() {
-            tracing::warn!("Error sealing segment on drop: {}", e);
+            tracing::warn!(error = %compact_error(&e), "error sealing segment on drop");
         }
     }
 }

--- a/crates/pensieve-ingest/src/relay/manager.rs
+++ b/crates/pensieve-ingest/src/relay/manager.rs
@@ -16,6 +16,7 @@ use rusqlite::Connection;
 use super::schema::{self, RelayStatus, RelayTier};
 use super::scoring::{self, RelayStatsForScoring};
 use super::url::{NormalizeResult, normalize_relay_url};
+use crate::logging::compact_error;
 use crate::{Error, Result};
 
 /// Configuration for the relay manager.
@@ -360,7 +361,11 @@ impl RelayManager {
                 RelayStatus::Active.as_str()
             ],
         ) {
-            tracing::error!("Failed to update relay status on disconnect: {}", e);
+            tracing::error!(
+                relay_url = %normalized,
+                error = %compact_error(&e),
+                "failed to update relay status on disconnect"
+            );
         }
     }
 
@@ -391,9 +396,9 @@ impl RelayManager {
         // Record as a connection failure (increments consecutive_failures, may block)
         if let Err(e) = self.update_connection_status(&normalized, false) {
             tracing::warn!(
-                "Failed to update connection status for rejected relay {}: {}",
-                normalized,
-                e
+                relay_url = %normalized,
+                error = %compact_error(&e),
+                "failed to update connection status for rejected relay"
             );
         }
     }
@@ -576,7 +581,7 @@ impl RelayManager {
 
             // Flush to database
             if let Err(e) = self.flush_accumulators(old_hour) {
-                tracing::error!("Failed to flush hour stats: {}", e);
+                tracing::error!(error = %compact_error(&e), "failed to flush hourly relay stats");
             }
         }
     }

--- a/crates/pensieve-ingest/src/source/jsonl.rs
+++ b/crates/pensieve-ingest/src/source/jsonl.rs
@@ -149,7 +149,6 @@ impl JsonlSource {
                 match serde_json::from_str::<NoteBuf>(&line) {
                     Ok(note) => {
                         if let Err(e) = pack_note_into(&note, &mut pack_buf) {
-                            let error = compact_error(&e);
                             tracing::warn!(
                                 line = line_num + 1,
                                 payload_bytes = line.len(),
@@ -157,7 +156,7 @@ impl JsonlSource {
                                 kind = note.kind,
                                 tag_count = note.tags.len(),
                                 content_len = note.content.len(),
-                                error = %error,
+                                error = %compact_error(&e),
                                 "notepack encoding failed"
                             );
                             stats.invalid_events += 1;
@@ -165,18 +164,17 @@ impl JsonlSource {
                             if self.config.continue_on_error {
                                 continue;
                             } else {
-                                return Err(Error::Notepack(error));
+                                return Err(Error::Notepack(e.to_string()));
                             }
                         }
                         // Parse event ID from the note
                         hex_to_bytes32(&note.id)?
                     }
                     Err(e) => {
-                        let error = compact_error(&e);
                         tracing::warn!(
                             line = line_num + 1,
                             payload_bytes = line.len(),
-                            error = %error,
+                            error = %compact_error(&e),
                             "json parse error"
                         );
                         stats.invalid_events += 1;
@@ -184,7 +182,7 @@ impl JsonlSource {
                         if self.config.continue_on_error {
                             continue;
                         } else {
-                            return Err(Error::Json(error));
+                            return Err(Error::Json(e.to_string()));
                         }
                     }
                 }
@@ -208,11 +206,10 @@ impl JsonlSource {
                         id_bytes
                     }
                     Err(e) => {
-                        let error = compact_error(&e);
                         tracing::warn!(
                             line = line_num + 1,
                             payload_bytes = line.len(),
-                            error = %error,
+                            error = %compact_error(&e),
                             "event validation failed"
                         );
                         stats.invalid_events += 1;
@@ -220,7 +217,7 @@ impl JsonlSource {
                         if self.config.continue_on_error {
                             continue;
                         } else {
-                            return Err(Error::Validation(error));
+                            return Err(Error::Validation(e.to_string()));
                         }
                     }
                 }

--- a/crates/pensieve-ingest/src/source/jsonl.rs
+++ b/crates/pensieve-ingest/src/source/jsonl.rs
@@ -5,6 +5,7 @@
 //! ready for the ingestion pipeline.
 
 use super::{EventSource, SourceMetadata, SourceStats};
+use crate::logging::compact_error;
 use crate::pipeline::PackedEvent;
 use crate::{Error, Result};
 use notepack::{NoteBuf, pack_note_into};
@@ -121,7 +122,11 @@ impl JsonlSource {
             let line = match line_result {
                 Ok(l) => l,
                 Err(e) => {
-                    tracing::warn!("Line {}: I/O error: {}", line_num + 1, e);
+                    tracing::warn!(
+                        line = line_num + 1,
+                        error = %compact_error(&e),
+                        "jsonl input read failed"
+                    );
                     stats.invalid_events += 1;
                     stats.json_errors += 1;
                     if self.config.continue_on_error {
@@ -144,26 +149,42 @@ impl JsonlSource {
                 match serde_json::from_str::<NoteBuf>(&line) {
                     Ok(note) => {
                         if let Err(e) = pack_note_into(&note, &mut pack_buf) {
-                            tracing::warn!("Line {}: Notepack encoding error: {}", line_num + 1, e);
+                            let error = compact_error(&e);
+                            tracing::warn!(
+                                line = line_num + 1,
+                                payload_bytes = line.len(),
+                                note_id = %note.id,
+                                kind = note.kind,
+                                tag_count = note.tags.len(),
+                                content_len = note.content.len(),
+                                error = %error,
+                                "notepack encoding failed"
+                            );
                             stats.invalid_events += 1;
                             stats.notepack_errors += 1;
                             if self.config.continue_on_error {
                                 continue;
                             } else {
-                                return Err(Error::Notepack(e.to_string()));
+                                return Err(Error::Notepack(error));
                             }
                         }
                         // Parse event ID from the note
                         hex_to_bytes32(&note.id)?
                     }
                     Err(e) => {
-                        tracing::warn!("Line {}: JSON parse error: {}", line_num + 1, e);
+                        let error = compact_error(&e);
+                        tracing::warn!(
+                            line = line_num + 1,
+                            payload_bytes = line.len(),
+                            error = %error,
+                            "json parse error"
+                        );
                         stats.invalid_events += 1;
                         stats.json_errors += 1;
                         if self.config.continue_on_error {
                             continue;
                         } else {
-                            return Err(Error::Json(e.to_string()));
+                            return Err(Error::Json(error));
                         }
                     }
                 }
@@ -187,13 +208,19 @@ impl JsonlSource {
                         id_bytes
                     }
                     Err(e) => {
-                        tracing::warn!("Line {}: Validation error: {}", line_num + 1, e);
+                        let error = compact_error(&e);
+                        tracing::warn!(
+                            line = line_num + 1,
+                            payload_bytes = line.len(),
+                            error = %error,
+                            "event validation failed"
+                        );
                         stats.invalid_events += 1;
                         stats.validation_errors += 1;
                         if self.config.continue_on_error {
                             continue;
                         } else {
-                            return Err(Error::Validation(e.to_string()));
+                            return Err(Error::Validation(error));
                         }
                     }
                 }
@@ -210,12 +237,12 @@ impl JsonlSource {
             match handler(packed_event) {
                 Ok(true) => {} // Continue
                 Ok(false) => {
-                    tracing::info!("Handler signaled stop");
+                    tracing::debug!("Handler signaled stop");
                     return Ok(false);
                 }
                 Err(e) => {
                     if self.config.continue_on_error {
-                        tracing::warn!("Handler error: {}", e);
+                        tracing::warn!(error = %compact_error(&e), "handler error");
                     } else {
                         return Err(e);
                     }
@@ -276,7 +303,11 @@ impl EventSource for JsonlSource {
                     break;
                 }
                 Err(e) => {
-                    tracing::warn!("Error processing {}: {}", file_path.display(), e);
+                    tracing::warn!(
+                        path = %file_path.display(),
+                        error = %compact_error(&e),
+                        "error processing jsonl file"
+                    );
                     if !self.config.continue_on_error {
                         return Err(e);
                     }

--- a/crates/pensieve-ingest/src/source/proto.rs
+++ b/crates/pensieve-ingest/src/source/proto.rs
@@ -5,6 +5,7 @@
 //! ready for the ingestion pipeline.
 
 use super::{EventSource, SourceMetadata, SourceStats};
+use crate::logging::compact_error;
 use crate::pipeline::PackedEvent;
 use crate::{Error, Result};
 use flate2::read::GzDecoder;
@@ -141,13 +142,14 @@ impl ProtoSource {
                     break;
                 }
                 Err(e) => {
-                    tracing::warn!("Protobuf decode error: {}", e);
+                    let error = compact_error(&e);
+                    tracing::warn!(error = %error, "protobuf decode failed");
                     stats.invalid_events += 1;
                     stats.proto_errors += 1;
                     if self.config.continue_on_error {
                         break;
                     } else {
-                        return Err(Error::Protobuf(e.to_string()));
+                        return Err(Error::Protobuf(error));
                     }
                 }
             };
@@ -161,13 +163,23 @@ impl ProtoSource {
                 match proto_to_notepack_unvalidated(&proto_event, &mut pack_buf) {
                     Ok(_) => hex_to_bytes32(&proto_event.id)?,
                     Err(e) => {
-                        tracing::warn!("Notepack encoding error: {}", e);
+                        let error = compact_error(&e);
+                        tracing::warn!(
+                            event_id = %proto_event.id,
+                            kind = proto_event.kind,
+                            pubkey = %proto_event.pubkey,
+                            tag_count = proto_event.tags.len(),
+                            content_len = proto_event.content.len(),
+                            payload_bytes = proto_bytes,
+                            error = %error,
+                            "protobuf event failed notepack encoding"
+                        );
                         stats.invalid_events += 1;
                         stats.proto_errors += 1;
                         if self.config.continue_on_error {
                             continue;
                         } else {
-                            return Err(Error::Notepack(e.to_string()));
+                            return Err(Error::Notepack(error));
                         }
                     }
                 }
@@ -179,13 +191,23 @@ impl ProtoSource {
                         id_bytes
                     }
                     Err(e) => {
-                        tracing::warn!("Validation error: {}", e);
+                        let error = compact_error(&e);
+                        tracing::warn!(
+                            event_id = %proto_event.id,
+                            kind = proto_event.kind,
+                            pubkey = %proto_event.pubkey,
+                            tag_count = proto_event.tags.len(),
+                            content_len = proto_event.content.len(),
+                            payload_bytes = proto_bytes,
+                            error = %error,
+                            "protobuf event validation failed"
+                        );
                         stats.invalid_events += 1;
                         stats.validation_errors += 1;
                         if self.config.continue_on_error {
                             continue;
                         } else {
-                            return Err(Error::Validation(e.to_string()));
+                            return Err(Error::Validation(error));
                         }
                     }
                 }
@@ -202,12 +224,12 @@ impl ProtoSource {
             match handler(packed_event) {
                 Ok(true) => {} // Continue
                 Ok(false) => {
-                    tracing::info!("Handler signaled stop");
+                    tracing::debug!("Handler signaled stop");
                     return Ok(false);
                 }
                 Err(e) => {
                     if self.config.continue_on_error {
-                        tracing::warn!("Handler error: {}", e);
+                        tracing::warn!(error = %compact_error(&e), "handler error");
                     } else {
                         return Err(e);
                     }
@@ -265,7 +287,11 @@ impl EventSource for ProtoSource {
                     break;
                 }
                 Err(e) => {
-                    tracing::warn!("Error processing {}: {}", file_path.display(), e);
+                    tracing::warn!(
+                        path = %file_path.display(),
+                        error = %compact_error(&e),
+                        "error processing protobuf file"
+                    );
                     if !self.config.continue_on_error {
                         return Err(e);
                     }

--- a/crates/pensieve-ingest/src/source/proto.rs
+++ b/crates/pensieve-ingest/src/source/proto.rs
@@ -142,14 +142,13 @@ impl ProtoSource {
                     break;
                 }
                 Err(e) => {
-                    let error = compact_error(&e);
-                    tracing::warn!(error = %error, "protobuf decode failed");
+                    tracing::warn!(error = %compact_error(&e), "protobuf decode failed");
                     stats.invalid_events += 1;
                     stats.proto_errors += 1;
                     if self.config.continue_on_error {
                         break;
                     } else {
-                        return Err(Error::Protobuf(error));
+                        return Err(Error::Protobuf(e.to_string()));
                     }
                 }
             };
@@ -163,7 +162,6 @@ impl ProtoSource {
                 match proto_to_notepack_unvalidated(&proto_event, &mut pack_buf) {
                     Ok(_) => hex_to_bytes32(&proto_event.id)?,
                     Err(e) => {
-                        let error = compact_error(&e);
                         tracing::warn!(
                             event_id = %proto_event.id,
                             kind = proto_event.kind,
@@ -171,7 +169,7 @@ impl ProtoSource {
                             tag_count = proto_event.tags.len(),
                             content_len = proto_event.content.len(),
                             payload_bytes = proto_bytes,
-                            error = %error,
+                            error = %compact_error(&e),
                             "protobuf event failed notepack encoding"
                         );
                         stats.invalid_events += 1;
@@ -179,7 +177,7 @@ impl ProtoSource {
                         if self.config.continue_on_error {
                             continue;
                         } else {
-                            return Err(Error::Notepack(error));
+                            return Err(Error::Notepack(e.to_string()));
                         }
                     }
                 }
@@ -191,7 +189,6 @@ impl ProtoSource {
                         id_bytes
                     }
                     Err(e) => {
-                        let error = compact_error(&e);
                         tracing::warn!(
                             event_id = %proto_event.id,
                             kind = proto_event.kind,
@@ -199,7 +196,7 @@ impl ProtoSource {
                             tag_count = proto_event.tags.len(),
                             content_len = proto_event.content.len(),
                             payload_bytes = proto_bytes,
-                            error = %error,
+                            error = %compact_error(&e),
                             "protobuf event validation failed"
                         );
                         stats.invalid_events += 1;
@@ -207,7 +204,7 @@ impl ProtoSource {
                         if self.config.continue_on_error {
                             continue;
                         } else {
-                            return Err(Error::Validation(error));
+                            return Err(Error::Validation(e.to_string()));
                         }
                     }
                 }

--- a/crates/pensieve-ingest/src/source/relay.rs
+++ b/crates/pensieve-ingest/src/source/relay.rs
@@ -18,6 +18,7 @@
 //! periodically optimizes which relays are connected based on quality scores.
 
 use super::{EventSource, SourceMetadata, SourceStats};
+use crate::logging::{compact_error, compact_notice};
 use crate::pipeline::PackedEvent;
 use crate::relay::RelayManager;
 use crate::relay::connection_guard::{ConnectionGuard, ConnectionGuardConfig};
@@ -373,7 +374,7 @@ impl RelaySource {
         // This allows us to authenticate with relays that require it
         // We don't use this key for signing events, just for relay auth
         let keys = Keys::generate();
-        tracing::info!(
+        tracing::debug!(
             "Generated ephemeral keypair for relay auth: {}",
             keys.public_key()
                 .to_bech32()
@@ -413,7 +414,11 @@ impl RelaySource {
             if let Some(ref manager) = self.relay_manager
                 && let Err(e) = manager.register_relay(relay_url, crate::relay::RelayTier::Seed)
             {
-                tracing::warn!("Failed to register seed relay {}: {}", relay_url, e);
+                tracing::warn!(
+                    relay_url = %relay_url,
+                    error = %compact_error(&e),
+                    "failed to register seed relay"
+                );
             }
 
             // Check DNS resolution for seed relays (skip rate limit check)
@@ -433,7 +438,11 @@ impl RelaySource {
             }
 
             if let Err(e) = client.add_relay(relay_url).await {
-                tracing::warn!("Failed to add relay {}: {}", relay_url, e);
+                tracing::warn!(
+                    relay_url = %relay_url,
+                    error = %compact_error(&e),
+                    "failed to add relay"
+                );
                 self.record_connection_failure(relay_url);
             } else {
                 tracing::debug!("Added relay: {}", relay_url);
@@ -486,7 +495,7 @@ impl RelaySource {
 
         // Subscribe
         let output = client.subscribe((*filter).clone(), None).await?;
-        tracing::info!("Subscribed with ID: {:?}", output.val);
+        tracing::debug!("Subscribed with ID: {:?}", output.val);
 
         // Get notification receiver
         let mut notifications = client.notifications();
@@ -538,7 +547,7 @@ impl RelaySource {
                 Ok(Ok(n)) => n,
                 Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
                     // All senders dropped - channel is truly closed
-                    tracing::info!("Notification channel closed");
+                    tracing::debug!("Notification channel closed");
                     break;
                 }
                 Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(count))) => {
@@ -594,18 +603,27 @@ impl RelaySource {
                     match handler(relay_url_str, &event) {
                         Ok(true) => {} // Continue
                         Ok(false) => {
-                            tracing::info!("Handler signaled stop");
+                            tracing::debug!("Handler signaled stop");
                             break;
                         }
                         Err(e) => {
-                            tracing::error!("Handler error: {}", e);
+                            tracing::error!(
+                                relay_url = %relay_url,
+                                event_id = %event.id,
+                                kind = event.kind.as_u16(),
+                                pubkey = %event.pubkey,
+                                tag_count = event.tags.len(),
+                                content_len = event.content.len(),
+                                error = %compact_error(&e),
+                                "relay event handler failed"
+                            );
                             break;
                         }
                     }
 
                     // Progress logging
                     if event_count.is_multiple_of(progress_interval) {
-                        tracing::info!(
+                        tracing::debug!(
                             "Received {} events, {} relays connected",
                             event_count,
                             self.stats.relays_connected.load(Ordering::Relaxed)
@@ -626,9 +644,9 @@ impl RelaySource {
                                 || msg_lower.contains("not allowed")
                             {
                                 tracing::warn!(
-                                    "Relay {} rejected access: {}. Disconnecting.",
-                                    relay_url,
-                                    notice_msg
+                                    relay_url = %relay_url,
+                                    notice = %compact_notice(&notice_msg),
+                                    "relay rejected access; disconnecting"
                                 );
                                 let relay_url_str = relay_url.to_string();
                                 // Record as rejection (counts as failure, may lead to blocking)
@@ -645,7 +663,11 @@ impl RelaySource {
                                 }
                                 self.stats.relays_connected.fetch_sub(1, Ordering::Relaxed);
                             } else {
-                                tracing::debug!("Relay {} notice: {}", relay_url, notice_msg);
+                                tracing::debug!(
+                                    relay_url = %relay_url,
+                                    notice = %compact_notice(&notice_msg),
+                                    "relay notice"
+                                );
                             }
                         }
                         RelayMessage::Closed {
@@ -659,10 +681,10 @@ impl RelaySource {
                                 || msg_lower.contains("not allowed")
                             {
                                 tracing::warn!(
-                                    "Relay {} closed subscription {}: {}. Disconnecting.",
-                                    relay_url,
-                                    subscription_id,
-                                    closed_msg
+                                    relay_url = %relay_url,
+                                    subscription_id = %subscription_id,
+                                    message = %compact_notice(&closed_msg),
+                                    "relay closed restricted subscription; disconnecting"
                                 );
                                 let relay_url_str = relay_url.to_string();
                                 // Record as rejection (counts as failure, may lead to blocking)
@@ -684,7 +706,7 @@ impl RelaySource {
                 }
 
                 RelayPoolNotification::Shutdown => {
-                    tracing::info!("Relay pool shutdown notification received");
+                    tracing::debug!("Relay pool shutdown notification received");
                     break;
                 }
             }
@@ -709,7 +731,7 @@ impl RelaySource {
 
         // First, recompute scores
         if let Err(e) = manager.recompute_scores() {
-            tracing::warn!("Failed to recompute relay scores: {}", e);
+            tracing::warn!(error = %compact_error(&e), "failed to recompute relay scores");
             return;
         }
 
@@ -729,7 +751,7 @@ impl RelaySource {
         let suggestions = match manager.get_optimization_suggestions(&connected_relays) {
             Ok(s) => s,
             Err(e) => {
-                tracing::warn!("Failed to get optimization suggestions: {}", e);
+                tracing::warn!(error = %compact_error(&e), "failed to get relay optimization suggestions");
                 return;
             }
         };
@@ -753,14 +775,18 @@ impl RelaySource {
 
         // Disconnect low-scoring relays
         for url in &suggestions.to_disconnect {
-            tracing::info!("Disconnecting low-scoring relay: {}", url);
+            tracing::debug!("Disconnecting low-scoring relay: {}", url);
             self.record_disconnection(url).await;
             self.connection_guard.record_disconnect(url);
             counter!("relay_disconnects_total", "reason" => "optimization").increment(1);
 
             if let Ok(relay_url) = RelayUrl::parse(url) {
                 if let Err(e) = client.disconnect_relay(relay_url).await {
-                    tracing::warn!("Failed to disconnect {}: {}", url, e);
+                    tracing::warn!(
+                        relay_url = %url,
+                        error = %compact_error(&e),
+                        "failed to disconnect relay"
+                    );
                 } else {
                     self.stats.relays_connected.fetch_sub(1, Ordering::Relaxed);
                 }
@@ -769,13 +795,13 @@ impl RelaySource {
 
         // Connect higher-scoring relays (swaps)
         for url in &suggestions.to_connect {
-            tracing::info!("Connecting higher-scoring relay: {}", url);
+            tracing::debug!("Connecting higher-scoring relay: {}", url);
             self.try_connect_relay(client, filter, url, "swap").await;
         }
 
         // Connect exploration relays (untested/stale relays)
         for url in &suggestions.exploration_relays {
-            tracing::info!("Exploring untested relay: {}", url);
+            tracing::debug!("Exploring untested relay: {}", url);
             counter!("relay_exploration_attempts_total").increment(1);
             self.try_connect_relay(client, filter, url, "exploration")
                 .await;
@@ -859,13 +885,22 @@ impl RelaySource {
                             .subscribe_to(vec![relay_url], (**filter).clone(), None)
                             .await
                     {
-                        tracing::warn!("Failed to subscribe new relay {}: {}", url, e);
+                        tracing::warn!(
+                            relay_url = %url,
+                            error = %compact_error(&e),
+                            "failed to subscribe new relay"
+                        );
                     }
                 }
                 Err(e) => {
                     // connect_relay() itself failed (not just the async handshake)
                     // This is a definitive, synchronous failure.
-                    tracing::warn!("Failed to connect to {}: {}", url, e);
+                    tracing::warn!(
+                        relay_url = %url,
+                        reason = reason,
+                        error = %compact_error(&e),
+                        "failed to connect relay"
+                    );
                     self.record_connection_failure(url);
                     counter!("relay_connect_failures_total", "reason" => reason).increment(1);
                 }
@@ -985,7 +1020,15 @@ impl EventSource for RelaySource {
             match pack_nostr_event(event) {
                 Ok(packed) => handler(packed),
                 Err(e) => {
-                    tracing::debug!("Failed to pack event: {}", e);
+                    tracing::debug!(
+                        event_id = %event.id,
+                        kind = event.kind.as_u16(),
+                        pubkey = %event.pubkey,
+                        tag_count = event.tags.len(),
+                        content_len = event.content.len(),
+                        error = %compact_error(&e),
+                        "failed to pack relay event"
+                    );
                     Ok(true) // Continue on pack errors
                 }
             }

--- a/crates/pensieve-ingest/src/sync/negentropy.rs
+++ b/crates/pensieve-ingest/src/sync/negentropy.rs
@@ -20,6 +20,7 @@
 
 use super::SyncStateDb;
 use crate::Result;
+use crate::logging::compact_error;
 use metrics::{counter, gauge, histogram};
 use nostr_sdk::prelude::*;
 use std::fmt::Debug;
@@ -258,7 +259,7 @@ impl NegentropySyncer {
         // Mark sync as in progress
         gauge!("negentropy_sync_in_progress").set(1.0);
 
-        tracing::info!(
+        tracing::debug!(
             "Starting negentropy sync with {} relays, lookback {}s",
             self.config.relays.len(),
             self.config.lookback.as_secs()
@@ -304,7 +305,11 @@ impl NegentropySyncer {
         // Add trusted relays
         for relay_url in &self.config.relays {
             if let Err(e) = client.add_relay(relay_url).await {
-                tracing::warn!("Failed to add negentropy relay {}: {}", relay_url, e);
+                tracing::warn!(
+                    relay_url = %relay_url,
+                    error = %compact_error(&e),
+                    "failed to add negentropy relay"
+                );
                 stats.relays_errored += 1;
             }
         }
@@ -331,13 +336,13 @@ impl NegentropySyncer {
                 stats.events_discovered = output.received.len();
                 stats.relays_responded = self.config.relays.len() - stats.relays_errored;
 
-                tracing::info!(
+                tracing::debug!(
                     "Negentropy reconciliation complete: {} events discovered",
                     stats.events_discovered
                 );
             }
             Ok(Err(e)) => {
-                tracing::warn!("Negentropy sync failed: {}", e);
+                tracing::warn!(error = %compact_error(&e), "negentropy sync failed");
                 stats.relays_errored = self.config.relays.len();
             }
             Err(_) => {
@@ -358,7 +363,7 @@ impl NegentropySyncer {
         // Wait for collector to finish receiving all events
         // The channel will close when the adapter is dropped
         if let Err(e) = collector_handle.await {
-            tracing::warn!("Event collector task failed: {}", e);
+            tracing::warn!(error = %compact_error(&e), "event collector task failed");
         }
 
         // Get collected events
@@ -369,7 +374,7 @@ impl NegentropySyncer {
         stats.events_received = discovered_events.len();
         stats.duration = start.elapsed();
 
-        tracing::info!(
+        tracing::debug!(
             "Negentropy sync captured {} events in {:?}",
             stats.events_received,
             stats.duration
@@ -442,12 +447,18 @@ impl NegentropySyncer {
                                     .sync_state
                                     .record(event.id.as_bytes(), event.created_at.as_secs())
                                 {
-                                    tracing::warn!("Failed to record event in sync state: {}", e);
+                                    tracing::warn!(
+                                        event_id = %event.id,
+                                        kind = event.kind.as_u16(),
+                                        pubkey = %event.pubkey,
+                                        error = %compact_error(&e),
+                                        "failed to record negentropy event in sync state"
+                                    );
                                 }
                                 events_succeeded += 1;
                             }
                             Ok(false) => {
-                                tracing::info!("Event handler signaled stop");
+                                tracing::debug!("Event handler signaled stop");
                                 self.running.store(false, Ordering::SeqCst);
                                 break;
                             }
@@ -455,8 +466,13 @@ impl NegentropySyncer {
                                 // Event failed to process - do NOT record in sync state.
                                 // It will be re-fetched on the next sync cycle.
                                 tracing::debug!(
-                                    "Event handler error (will retry next sync): {}",
-                                    e
+                                    event_id = %event.id,
+                                    kind = event.kind.as_u16(),
+                                    pubkey = %event.pubkey,
+                                    tag_count = event.tags.len(),
+                                    content_len = event.content.len(),
+                                    error = %compact_error(&e),
+                                    "negentropy event handler failed; will retry next sync"
                                 );
                                 events_failed += 1;
                                 counter!("negentropy_events_failed_total").increment(1);
@@ -467,7 +483,7 @@ impl NegentropySyncer {
                     let process_duration = process_start.elapsed();
 
                     // Log batch summary
-                    tracing::info!(
+                    tracing::debug!(
                         "Negentropy batch processed: {} events → {} succeeded, {} failed in {:?}",
                         total_events,
                         events_succeeded,
@@ -497,7 +513,7 @@ impl NegentropySyncer {
                             }
                         }
                         Err(e) => {
-                            tracing::warn!("Failed to prune sync state: {}", e);
+                            tracing::warn!(error = %compact_error(&e), "failed to prune sync state");
                         }
                     }
 
@@ -507,7 +523,7 @@ impl NegentropySyncer {
                     }
                 }
                 Err(e) => {
-                    tracing::error!("Negentropy sync cycle failed: {}", e);
+                    tracing::error!(error = %compact_error(&e), "negentropy sync cycle failed");
                     counter!("negentropy_sync_errors_total").increment(1);
                 }
             }

--- a/crates/pensieve-preview/src/main.rs
+++ b/crates/pensieve-preview/src/main.rs
@@ -6,7 +6,7 @@
 use axum::http::Request;
 use clap::Parser;
 use tower_http::cors::{Any, CorsLayer};
-use tower_http::trace::TraceLayer;
+use tower_http::trace::{DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer};
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -51,12 +51,7 @@ async fn main() -> anyhow::Result<()> {
     // Warm up ClickHouse connection pool before accepting requests.
     // The clickhouse crate creates connections lazily, so the first user
     // request would otherwise pay ~100-200ms for TCP setup + pool init.
-    match state
-        .clickhouse
-        .query("SELECT 1")
-        .fetch_one::<u8>()
-        .await
-    {
+    match state.clickhouse.query("SELECT 1").fetch_one::<u8>().await {
         Ok(_) => tracing::info!("clickhouse connection warm-up complete"),
         Err(e) => tracing::warn!(%e, "clickhouse warm-up failed (will retry on first request)"),
     }
@@ -64,14 +59,18 @@ async fn main() -> anyhow::Result<()> {
     // Build router with middleware
     let app = router(state)
         .layer(
-            TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
-                tracing::span!(
-                    Level::INFO,
-                    "http_request",
-                    method = %request.method(),
-                    path = %request.uri().path(),
-                )
-            }),
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &Request<_>| {
+                    tracing::span!(
+                        Level::DEBUG,
+                        "http_request",
+                        method = %request.method(),
+                        path = %request.uri().path(),
+                    )
+                })
+                .on_request(DefaultOnRequest::new().level(Level::DEBUG))
+                .on_response(DefaultOnResponse::new().level(Level::DEBUG))
+                .on_failure(DefaultOnFailure::new().level(Level::WARN)),
         )
         .layer(
             CorsLayer::new()

--- a/crates/pensieve-preview/src/main.rs
+++ b/crates/pensieve-preview/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
             TraceLayer::new_for_http()
                 .make_span_with(|request: &Request<_>| {
                     tracing::span!(
-                        Level::DEBUG,
+                        Level::INFO,
                         "http_request",
                         method = %request.method(),
                         path = %request.uri().path(),

--- a/crates/pensieve-preview/src/render/article.rs
+++ b/crates/pensieve-preview/src/render/article.rs
@@ -3,12 +3,12 @@
 //! Renders articles with title, author info, and full markdown content.
 //! Markdown is converted to HTML using pulldown-cmark.
 
-use maud::{html, Markup, PreEscaped};
-use pulldown_cmark::{html as md_html, Options, Parser};
+use maud::{Markup, PreEscaped, html};
+use pulldown_cmark::{Options, Parser, html as md_html};
 
 use super::components::{
-    author_header, engagement_bar, is_safe_url, kind_badge, nostr_link, page_shell, truncate,
-    OpenGraphData,
+    OpenGraphData, author_header, engagement_bar, is_safe_url, kind_badge, nostr_link, page_shell,
+    truncate,
 };
 use crate::query::{EngagementCounts, EventRow, ProfileMetadata};
 

--- a/crates/pensieve-preview/src/render/generic.rs
+++ b/crates/pensieve-preview/src/render/generic.rs
@@ -4,12 +4,12 @@
 
 use std::collections::HashMap;
 
-use maud::{html, Markup};
+use maud::{Markup, html};
 
 use super::components::{
-    author_header, engagement_bar, kind_badge, nostr_link, page_shell, truncate, OpenGraphData,
+    OpenGraphData, author_header, engagement_bar, kind_badge, nostr_link, page_shell, truncate,
 };
-use super::content::{render_content, QuotedEvent};
+use super::content::{QuotedEvent, render_content};
 use crate::query::{EngagementCounts, EventRow, ProfileMetadata};
 
 /// Render a generic event preview page.

--- a/crates/pensieve-preview/src/render/mod.rs
+++ b/crates/pensieve-preview/src/render/mod.rs
@@ -180,9 +180,8 @@ fn extract_referenced_pubkeys(content: &str, tags: &[Vec<String>]) -> Vec<String
     use std::collections::HashSet;
     use std::sync::LazyLock;
 
-    static NOSTR_PUBKEY_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-        regex::Regex::new(r"nostr:(npub1|nprofile1)[a-z0-9]+").unwrap()
-    });
+    static NOSTR_PUBKEY_RE: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"nostr:(npub1|nprofile1)[a-z0-9]+").unwrap());
 
     let mut pubkeys = HashSet::new();
 

--- a/crates/pensieve-preview/src/render/note.rs
+++ b/crates/pensieve-preview/src/render/note.rs
@@ -5,12 +5,12 @@
 
 use std::collections::HashMap;
 
-use maud::{html, Markup};
+use maud::{Markup, html};
 
 use super::components::{
-    author_header, engagement_bar, nostr_link, page_shell, truncate, OpenGraphData,
+    OpenGraphData, author_header, engagement_bar, nostr_link, page_shell, truncate,
 };
-use super::content::{render_content, QuotedEvent};
+use super::content::{QuotedEvent, render_content};
 use crate::query::{EngagementCounts, EventRow, ProfileMetadata};
 
 /// Render a text note preview page.

--- a/crates/pensieve-preview/src/render/profile.rs
+++ b/crates/pensieve-preview/src/render/profile.rs
@@ -3,13 +3,13 @@
 //! Renders a user's profile page with banner, avatar, name, NIP-05,
 //! about text, and metadata links.
 
-use maud::{html, Markup};
+use maud::{Markup, html};
 
 use maud::PreEscaped;
 
 use super::components::{
-    self, is_safe_url, nostr_link, page_shell, truncate, truncate_npub_display, OpenGraphData,
-    ICON_COPY,
+    self, ICON_COPY, OpenGraphData, is_safe_url, nostr_link, page_shell, truncate,
+    truncate_npub_display,
 };
 use crate::query::ProfileMetadata;
 

--- a/crates/pensieve-preview/src/render/repost.rs
+++ b/crates/pensieve-preview/src/render/repost.rs
@@ -5,12 +5,12 @@
 
 use std::collections::HashMap;
 
-use maud::{html, Markup};
+use maud::{Markup, html};
 
 use super::components::{
-    author_header, engagement_bar, nostr_link, page_shell, truncate, truncate_key, OpenGraphData,
+    OpenGraphData, author_header, engagement_bar, nostr_link, page_shell, truncate, truncate_key,
 };
-use super::content::{render_content, QuotedEvent};
+use super::content::{QuotedEvent, render_content};
 use crate::query::{EngagementCounts, EventRow, ProfileMetadata};
 
 /// Render a repost preview page.

--- a/crates/pensieve-preview/src/render/video.rs
+++ b/crates/pensieve-preview/src/render/video.rs
@@ -3,11 +3,11 @@
 //! Renders video events with thumbnail, title, author info,
 //! and engagement counts.
 
-use maud::{html, Markup};
+use maud::{Markup, html};
 
 use super::components::{
-    author_header, engagement_bar, is_safe_url, kind_badge, nostr_link, page_shell, truncate,
-    OpenGraphData,
+    OpenGraphData, author_header, engagement_bar, is_safe_url, kind_badge, nostr_link, page_shell,
+    truncate,
 };
 use crate::query::{EngagementCounts, EventRow, ProfileMetadata};
 

--- a/crates/pensieve-preview/src/routes/og.rs
+++ b/crates/pensieve-preview/src/routes/og.rs
@@ -39,11 +39,11 @@ pub async fn og_image_handler(
 
     // Check OG image cache
     if let Some(cached) = state.og_cache.get(identifier).await {
-        tracing::debug!(identifier = %identifier, "og image cache hit");
+        tracing::trace!(identifier = %identifier, "og image cache hit");
         return Ok(png_response(&cached));
     }
 
-    tracing::debug!(identifier = %identifier, "og image cache miss, generating");
+    tracing::trace!(identifier = %identifier, "og image cache miss, generating");
 
     // Resolve the identifier to get the avatar URL
     let avatar_url = match resolve::resolve(&state, identifier).await {
@@ -86,9 +86,7 @@ fn png_response(png_bytes: &[u8]) -> Response {
 /// Extract the avatar URL from resolved content.
 fn extract_avatar_url(content: &resolve::ResolvedContent) -> Option<String> {
     match content {
-        resolve::ResolvedContent::Profile { metadata, .. } => {
-            metadata.picture.clone()
-        }
+        resolve::ResolvedContent::Profile { metadata, .. } => metadata.picture.clone(),
         resolve::ResolvedContent::Event { author, .. } => {
             author.as_ref().and_then(|a| a.picture.clone())
         }
@@ -182,7 +180,11 @@ fn generate_og_image(avatar_bytes: Option<&[u8]>) -> Result<Vec<u8>, PreviewErro
     let mut pixmap = resvg::tiny_skia::Pixmap::new(OG_WIDTH, OG_HEIGHT)
         .ok_or_else(|| PreviewError::Internal(anyhow::anyhow!("failed to create pixmap")))?;
 
-    resvg::render(&tree, resvg::tiny_skia::Transform::default(), &mut pixmap.as_mut());
+    resvg::render(
+        &tree,
+        resvg::tiny_skia::Transform::default(),
+        &mut pixmap.as_mut(),
+    );
 
     // Encode as PNG
     let png_data = pixmap

--- a/crates/pensieve-preview/src/routes/preview.rs
+++ b/crates/pensieve-preview/src/routes/preview.rs
@@ -33,14 +33,14 @@ pub async fn preview_handler(
 
     // Check in-process cache
     if let Some(cached) = state.cache.get(identifier).await {
-        tracing::debug!(identifier = %identifier, "cache hit");
+        tracing::trace!(identifier = %identifier, "cache hit");
         return Ok(build_response(
             &cached.html,
             cache_headers(&state, identifier, None),
         ));
     }
 
-    tracing::debug!(identifier = %identifier, "cache miss, resolving");
+    tracing::trace!(identifier = %identifier, "cache miss, resolving");
 
     // Resolve the identifier
     let content = resolve::resolve(&state, identifier).await?;

--- a/crates/pensieve-serve/src/cache.rs
+++ b/crates/pensieve-serve/src/cache.rs
@@ -127,7 +127,7 @@ where
         return Ok(value);
     }
 
-    tracing::debug!(key = %key, ttl_secs = ttl.as_secs(), "cache miss, computing");
+    tracing::trace!(key = %key, ttl_secs = ttl.as_secs(), "cache miss, computing");
     let value = compute().await?;
 
     match serde_json::to_string(&value) {
@@ -158,13 +158,13 @@ where
     if let Some(entry) = cache.get(key).await {
         if chrono::Utc::now() > entry.expires_at {
             cache.invalidate(key).await;
-            tracing::debug!(key = %key, expired_at = %entry.expires_at, "cache expired");
+            tracing::trace!(key = %key, expired_at = %entry.expires_at, "cache expired");
             return Ok(None);
         }
 
         return match serde_json::from_str(&entry.json) {
             Ok(value) => {
-                tracing::debug!(
+                tracing::trace!(
                     key = %key,
                     cached_at = %entry.cached_at,
                     expires_at = %entry.expires_at,

--- a/crates/pensieve-serve/src/error.rs
+++ b/crates/pensieve-serve/src/error.rs
@@ -56,12 +56,7 @@ impl IntoResponse for ApiError {
                 )
             }
             Self::Database(err) => {
-                // Include the full error details for debugging
-                tracing::error!(
-                    error = %err,
-                    error_debug = ?err,
-                    "database error"
-                );
+                tracing::error!(error = %err, "database error");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "database_error",

--- a/crates/pensieve-serve/src/main.rs
+++ b/crates/pensieve-serve/src/main.rs
@@ -54,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
             TraceLayer::new_for_http()
                 .make_span_with(|request: &Request<_>| {
                     tracing::span!(
-                        Level::DEBUG,
+                        Level::INFO,
                         "http_request",
                         method = %request.method(),
                         path = %request.uri().path(),

--- a/crates/pensieve-serve/src/main.rs
+++ b/crates/pensieve-serve/src/main.rs
@@ -6,7 +6,7 @@
 use axum::http::Request;
 use clap::Parser;
 use tower_http::cors::{Any, CorsLayer};
-use tower_http::trace::TraceLayer;
+use tower_http::trace::{DefaultOnFailure, DefaultOnRequest, DefaultOnResponse, TraceLayer};
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -51,15 +51,19 @@ async fn main() -> anyhow::Result<()> {
     // Build router with middleware
     let app = router(state)
         .layer(
-            TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
-                tracing::span!(
-                    Level::INFO,
-                    "http_request",
-                    method = %request.method(),
-                    path = %request.uri().path(),
-                    query = request.uri().query().unwrap_or("")
-                )
-            }),
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &Request<_>| {
+                    tracing::span!(
+                        Level::DEBUG,
+                        "http_request",
+                        method = %request.method(),
+                        path = %request.uri().path(),
+                        query = request.uri().query().unwrap_or("")
+                    )
+                })
+                .on_request(DefaultOnRequest::new().level(Level::DEBUG))
+                .on_response(DefaultOnResponse::new().level(Level::DEBUG))
+                .on_failure(DefaultOnFailure::new().level(Level::WARN)),
         )
         .layer(
             CorsLayer::new()

--- a/crates/pensieve-serve/src/state.rs
+++ b/crates/pensieve-serve/src/state.rs
@@ -127,11 +127,11 @@ impl AppState {
                     | rusqlite::OpenFlags::SQLITE_OPEN_URI,
             ) {
                 Ok(conn) => {
-                    tracing::info!("Relay database connected (immutable): {:?}", path);
+                    tracing::info!(path = %path.display(), "relay database connected (immutable)");
                     Some(Arc::new(Mutex::new(conn)))
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to open relay database {:?}: {}", path, e);
+                    tracing::warn!(path = %path.display(), error = %e, "failed to open relay database");
                     None
                 }
             }

--- a/pensieve-deploy/systemd/pensieve-api.service
+++ b/pensieve-deploy/systemd/pensieve-api.service
@@ -21,7 +21,7 @@ RestartSec=5
 EnvironmentFile=/home/pensieve/pensieve/pensieve-deploy/.env
 
 # Additional environment
-Environment=RUST_LOG=info,pensieve_serve=debug
+Environment=RUST_LOG=info
 
 # Logging
 StandardOutput=journal

--- a/pensieve-deploy/systemd/pensieve-ingest.service
+++ b/pensieve-deploy/systemd/pensieve-ingest.service
@@ -16,6 +16,9 @@ WorkingDirectory=/home/pensieve/pensieve
 #
 # Negentropy sync (NIP-77) enabled - periodically reconciles with trusted relays
 # to discover events missed during normal streaming
+#
+# Add --verbose-ops to ExecStart when you want periodic throughput/checkpoint
+# progress at INFO without raising RUST_LOG for everything else.
 ExecStart=/home/pensieve/pensieve/target/release/pensieve-ingest \
     --seed-file /home/pensieve/pensieve/data/relays/seed.txt \
     --import-discovered-json /home/pensieve/pensieve/data/relays/relay_discovery_results.json \
@@ -36,7 +39,7 @@ Restart=always
 RestartSec=10
 
 # Environment
-Environment=RUST_LOG=info,pensieve_ingest=debug
+Environment=RUST_LOG=info
 
 # Logging
 StandardOutput=journal

--- a/pensieve-deploy/systemd/pensieve-preview.service
+++ b/pensieve-deploy/systemd/pensieve-preview.service
@@ -21,7 +21,7 @@ RestartSec=5
 EnvironmentFile=/home/pensieve/pensieve/pensieve-deploy/.env
 
 # Additional environment
-Environment=RUST_LOG=info,pensieve_preview=debug
+Environment=RUST_LOG=info
 
 # Logging
 StandardOutput=journal

--- a/pensieve-local/README.md
+++ b/pensieve-local/README.md
@@ -46,7 +46,7 @@ Or with all options:
 ```bash
 PENSIEVE_API_TOKENS=dev-token \
 CLICKHOUSE_URL=http://localhost:8123 \
-RUST_LOG=info,pensieve_serve=debug \
+RUST_LOG=info \
 cargo run --bin pensieve-serve
 ```
 
@@ -89,6 +89,10 @@ mkdir -p ./data/dedupe ./data/segments
   --metrics-port 9091 \
   --score-interval-secs 60
 ```
+
+For live tuning, add `--verbose-ops` to emit periodic throughput and checkpoint
+progress at INFO without turning on broader debug logging.
+
 
 ## Grafana Dashboards
 


### PR DESCRIPTION
## Summary
- make tracing default to `info` everywhere when `RUST_LOG` is unset
- set deployed ingest/api/preview services to `RUST_LOG=info`
- reduce ingest/api/preview log noise with more structured, compact logging
- add `--verbose-ops` for ingest throughput/checkpoint progress at INFO when needed

## Details
- remove forced `pensieve_ingest=debug` behavior from code and systemd
- keep routine API/preview request tracing at DEBUG and failures at WARN
- demote cache hit/miss chatter to TRACE
- replace noisy raw warn/error logs with structured fields and compacted error strings
- document `--verbose-ops` in deploy/local docs

## Verification
- `just precommit`