### PR TITLE
Suppress noisy upstream relay pool logging and fix systemd env override

### DIFF
--- a/crates/pensieve-ingest/src/bin/jsonl.rs
+++ b/crates/pensieve-ingest/src/bin/jsonl.rs
@@ -162,9 +162,12 @@ impl Progress {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize tracing
+    // Initialize tracing (suppress noisy upstream crates by default)
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,nostr_relay_pool=off,nostr_sdk=warn".into()),
+        )
         .init();
 
     let args = Args::parse();

--- a/crates/pensieve-ingest/src/bin/proto.rs
+++ b/crates/pensieve-ingest/src/bin/proto.rs
@@ -187,9 +187,12 @@ impl Progress {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize tracing
+    // Initialize tracing (suppress noisy upstream crates by default)
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,nostr_relay_pool=off,nostr_sdk=warn".into()),
+        )
         .init();
 
     let args = Args::parse();

--- a/crates/pensieve-ingest/src/bin/repair-dedupe.rs
+++ b/crates/pensieve-ingest/src/bin/repair-dedupe.rs
@@ -48,8 +48,12 @@ struct Args {
 }
 
 fn main() -> Result<()> {
+    // Suppress noisy upstream crates by default
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,nostr_relay_pool=off,nostr_sdk=warn".into()),
+        )
         .init();
 
     let args = Args::parse();

--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -232,8 +232,20 @@ async fn main() -> Result<()> {
         .expect("Failed to install rustls crypto provider");
 
     // Initialize tracing
+    //
+    // Suppress noisy upstream crates completely by default:
+    // - nostr_relay_pool: dumps full event payloads (thousands of tags) in ERROR
+    //   messages, negentropy progress spam at INFO, connection chatter at INFO.
+    //   We handle all relay error/status reporting ourselves with compact_error().
+    // - nostr_sdk: internal client chatter
+    //
+    // Override with RUST_LOG for debugging (e.g. RUST_LOG=debug or
+    // RUST_LOG=info,nostr_relay_pool=debug).
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,nostr_relay_pool=off,nostr_sdk=warn".into()),
+        )
         .init();
 
     let args = Args::parse();

--- a/pensieve-deploy/systemd/pensieve-api.service
+++ b/pensieve-deploy/systemd/pensieve-api.service
@@ -20,8 +20,9 @@ RestartSec=5
 # Environment file (for PENSIEVE_API_TOKENS, CLICKHOUSE_URL, etc.)
 EnvironmentFile=/home/pensieve/pensieve/pensieve-deploy/.env
 
-# Additional environment
-Environment=RUST_LOG=info
+# Logging: the binary defaults to info with noisy upstream crates suppressed.
+# To override:  systemctl edit pensieve-api  →  Environment=RUST_LOG=debug
+# Environment=RUST_LOG=info
 
 # Logging
 StandardOutput=journal

--- a/pensieve-deploy/systemd/pensieve-ingest.service
+++ b/pensieve-deploy/systemd/pensieve-ingest.service
@@ -38,8 +38,9 @@ ExecStart=/home/pensieve/pensieve/target/release/pensieve-ingest \
 Restart=always
 RestartSec=10
 
-# Environment
-Environment=RUST_LOG=info
+# Logging: the binary defaults to info with noisy upstream crates suppressed.
+# To override:  systemctl edit pensieve-ingest  →  Environment=RUST_LOG=debug
+# Environment=RUST_LOG=info
 
 # Logging
 StandardOutput=journal

--- a/pensieve-deploy/systemd/pensieve-preview.service
+++ b/pensieve-deploy/systemd/pensieve-preview.service
@@ -20,8 +20,9 @@ RestartSec=5
 # Environment file (for CLICKHOUSE_URL, PREVIEW_BASE_URL, etc.)
 EnvironmentFile=/home/pensieve/pensieve/pensieve-deploy/.env
 
-# Additional environment
-Environment=RUST_LOG=info
+# Logging: the binary defaults to info with noisy upstream crates suppressed.
+# To override:  systemctl edit pensieve-preview  →  Environment=RUST_LOG=debug
+# Environment=RUST_LOG=info
 
 # Logging
 StandardOutput=journal


### PR DESCRIPTION
## Changes

- **Logging filters**: Updated tracing initialization in `main.rs`, `jsonl.rs`, `proto.rs`, and `repair-dedupe.rs` to suppress verbose upstream crates by default:
  - `nostr_relay_pool=off`: Eliminates full event payload dumps and connection chatter
  - `nostr_sdk=warn`: Reduces internal client chatter
  - Added detailed comments explaining the rationale

- **Systemd service files**: Updated `pensieve-api.service`, `pensieve-ingest.service`, and `pensieve-preview.service`:
  - Commented out hardcoded `Environment=RUST_LOG=info` to allow binary defaults
  - Added documentation for overriding with `systemctl edit` for debugging
  - Clarified that binaries now suppress noisy upstream crates by default

## Impact

Cleaner logs in production while maintaining easy debugging via `RUST_LOG` override.