### PR TITLE
Fix local dev setup: Docker mount footgun, missing prerequisites docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Thumbs.db
 
 # Local data directories (RocksDB, archive segments, etc.)
 data/
+segments/
 
 # Local code-review artifacts
 reviews/

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ Import events from length-delimited protobuf files. Supports local files or S3 w
 | `--temp-dir` | system | Temp directory for S3 downloads |
 | `--metrics-port` | `9091` | Prometheus metrics port |
 
+## Prerequisites
+
+- **Rust** ≥ 1.90 (edition 2024) — `rustup update stable`
+- **protoc** (Protocol Buffers compiler) — required by the `pensieve-core` build script
+  - Debian/Ubuntu: `sudo apt-get install protobuf-compiler`
+  - macOS: `brew install protobuf`
+- **just** — task runner for all dev commands (`cargo install just`)
+- **Docker + Docker Compose** — for local infrastructure (ClickHouse, Prometheus, Grafana)
+
 ## Quick Start
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -124,6 +124,10 @@ doc-open:
 
 # Start local dev services (ClickHouse, etc.)
 dev-up:
+    # Ensure relay-stats.db exists as a file before Docker mounts it,
+    # otherwise Docker creates it as a root-owned directory.
+    mkdir -p data
+    touch data/relay-stats.db
     docker compose -f pensieve-local/docker-compose.yml up -d
 
 # Stop local dev services

--- a/pensieve-local/README.md
+++ b/pensieve-local/README.md
@@ -10,17 +10,15 @@ Local Docker environment for developing and testing Pensieve.
 ## Quick Start
 
 ```bash
-# From this directory
-cd pensieve-local
-
-# Start all services
-docker compose up -d
+# From the repo root — ensures data/relay-stats.db exists as a file before
+# Docker mounts it (otherwise Docker creates it as a root-owned directory)
+just dev-up
 
 # Check status
-docker compose ps
+cd pensieve-local && docker compose ps
 
 # View logs
-docker compose logs -f
+just dev-logs
 ```
 
 ## Services


### PR DESCRIPTION
## Changes

- **justfile**: `dev-up` ensures `data/relay-stats.db` exists before `docker compose up`. Grafana bind-mounts this file; on a fresh clone Docker creates the missing path as a root-owned directory, which later breaks the ingester with `PermissionDenied` on RocksDB.
- **pensieve-local/README.md**: Quick Start now uses `just dev-up` instead of raw `docker compose up -d`, so the documented path goes through the same guard.
- **README**: added Prerequisites section (Rust ≥ 1.90, `protoc`, `just`, Docker). `protoc` is required by the `pensieve-core` build script but wasn't documented.
- **.gitignore**: ignore `segments/` (created by the Quick Start command).

## Impact

A fresh clone now goes from `git clone` to a working local dev environment by following the README.

## Verification

- `just precommit` passes
- Verified on a fresh Linux setup: `dev-up` → migrations → live ingestion with Grafana dashboards populated

**Reviewer note:** `pensieve-deploy/docker-compose.yml` has the same single-file bind mount for `/data/relay-stats.db`, and the deploy README's directory-setup section doesn't pre-create it — same latent footgun on a fresh production deploy. Left out of scope here; happy to open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)