### PR TITLE
NIP-66 relay catalog consumer (first slice)

### DIFF
--- a/crates/pensieve-core/src/metrics.rs
+++ b/crates/pensieve-core/src/metrics.rs
@@ -203,6 +203,12 @@ fn register_common_metrics() {
         "Referenced event ids present in the dedupe index (coverage = present/referenced)"
     );
 
+    // NIP-66 relay catalog.
+    describe_counter!(
+        "ingest_nip66_relay_discovery_total",
+        "NIP-66 relay discovery (kind 30166) events recorded into the relay catalog"
+    );
+
     // =========================================================================
     // Relay Manager Metrics
     // =========================================================================

--- a/crates/pensieve-core/src/metrics.rs
+++ b/crates/pensieve-core/src/metrics.rs
@@ -208,6 +208,10 @@ fn register_common_metrics() {
         "ingest_nip66_relay_discovery_total",
         "NIP-66 relay discovery (kind 30166) events recorded into the relay catalog"
     );
+    describe_counter!(
+        "ingest_nip66_relay_discovery_errors_total",
+        "NIP-66 relay discovery events that failed to record into the catalog"
+    );
 
     // =========================================================================
     // Relay Manager Metrics

--- a/crates/pensieve-ingest/src/lib.rs
+++ b/crates/pensieve-ingest/src/lib.rs
@@ -63,8 +63,9 @@ pub use source::{
 
 // Re-export relay manager types
 pub use relay::{
-    AggregateRelayStats, ConnectionGuard, ConnectionGuardConfig, OptimizationSuggestions,
-    RelayManager, RelayManagerConfig, RelayStatus, RelayTier,
+    AggregateRelayStats, ConnectionGuard, ConnectionGuardConfig, KIND_RELAY_DISCOVERY,
+    OptimizationSuggestions, RelayCatalogEntry, RelayManager, RelayManagerConfig, RelayStatus,
+    RelayTier, parse_relay_discovery,
 };
 
 // Re-export sync types

--- a/crates/pensieve-ingest/src/lib.rs
+++ b/crates/pensieve-ingest/src/lib.rs
@@ -64,8 +64,8 @@ pub use source::{
 // Re-export relay manager types
 pub use relay::{
     AggregateRelayStats, ConnectionGuard, ConnectionGuardConfig, KIND_RELAY_DISCOVERY,
-    OptimizationSuggestions, RelayCatalogEntry, RelayManager, RelayManagerConfig, RelayStatus,
-    RelayTier, parse_relay_discovery,
+    OptimizationSuggestions, RelayCatalogEntry, RelayId, RelayManager, RelayManagerConfig,
+    RelayStatus, RelayTier, parse_relay_discovery,
 };
 
 // Re-export sync types

--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -88,6 +88,24 @@ fn load_seeds_from_file(path: &std::path::Path) -> Result<Vec<String>> {
     Ok(seeds)
 }
 
+/// Record a NIP-66 relay-discovery event into the catalog. Shared by all
+/// ingestion paths; a no-op for non-30166 events. Call only for accepted
+/// (archived) events so catalog contents track the archive, not arrival path.
+fn record_relay_discovery(manager: &RelayManager, event: &nostr_sdk::Event) {
+    if let Some(entry) = parse_relay_discovery(event) {
+        match manager.record_catalog_entry(&entry) {
+            Ok(()) => counter!("ingest_nip66_relay_discovery_total").increment(1),
+            Err(e) => {
+                counter!("ingest_nip66_relay_discovery_errors_total").increment(1);
+                tracing::debug!(
+                    error = %compact_error(&e),
+                    "failed to record relay catalog entry"
+                );
+            }
+        }
+    }
+}
+
 /// Pensieve live ingestion daemon.
 #[derive(Parser, Debug)]
 #[command(name = "pensieve-ingest")]
@@ -749,6 +767,7 @@ async fn main() -> Result<()> {
         let negentropy_events_processed = Arc::clone(&events_processed);
         let negentropy_events_deduplicated = Arc::clone(&events_deduplicated);
         let negentropy_max_created_at = Arc::clone(&max_created_at);
+        let negentropy_relay_manager = Arc::clone(&relay_manager);
 
         Some(tokio::spawn(async move {
             tracing::info!("Starting negentropy sync task...");
@@ -832,6 +851,9 @@ async fn main() -> Result<()> {
                         negentropy_max_created_at.fetch_max(clamped_ts, Ordering::Relaxed);
 
                         counter!("negentropy_events_written_total").increment(1);
+
+                        // NIP-66: record relay-discovery events we just archived.
+                        record_relay_discovery(&negentropy_relay_manager, event);
                     } else {
                         negentropy_events_deduplicated.fetch_add(1, Ordering::Relaxed);
                         counter!("negentropy_events_deduplicated_total").increment(1);
@@ -907,18 +929,6 @@ async fn main() -> Result<()> {
             // already contain the events this one references?
             coverage.observe(event);
 
-            // NIP-66: relay-discovery (kind 30166) events feed the relay catalog.
-            // parse_relay_discovery returns None for every other kind.
-            if let Some(entry) = parse_relay_discovery(event) {
-                if let Err(e) = handler_relay_manager.record_catalog_entry(&entry) {
-                    tracing::debug!(
-                        error = %compact_error(&e),
-                        "failed to record relay catalog entry"
-                    );
-                }
-                counter!("ingest_nip66_relay_discovery_total").increment(1);
-            }
-
             if is_novel {
                 // New event - NOW pack it (only for novel events)
                 match pack_nostr_event(event) {
@@ -951,6 +961,9 @@ async fn main() -> Result<()> {
                                 .as_secs();
                             let clamped_ts = event_ts.min(now);
                             handler_max_created_at.fetch_max(clamped_ts, Ordering::Relaxed);
+
+                            // NIP-66: record relay-discovery events we just archived.
+                            record_relay_discovery(&handler_relay_manager, event);
                         }
                     }
                     Err(e) => {

--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -37,7 +37,7 @@ use pensieve_ingest::{
     NegentropySyncer, RelayManager, RelayManagerConfig, SealedSegment, SegmentConfig,
     SegmentWriter, SyncStateDb,
     logging::compact_error,
-    pack_nostr_event,
+    pack_nostr_event, parse_relay_discovery,
     relay::normalize_relay_url,
     seed_from_clickhouse,
     source::{RelayConfig, RelaySource},
@@ -906,6 +906,18 @@ async fn main() -> Result<()> {
             // Reference-coverage sampling (sampled + cheap): does our archive
             // already contain the events this one references?
             coverage.observe(event);
+
+            // NIP-66: relay-discovery (kind 30166) events feed the relay catalog.
+            // parse_relay_discovery returns None for every other kind.
+            if let Some(entry) = parse_relay_discovery(event) {
+                if let Err(e) = handler_relay_manager.record_catalog_entry(&entry) {
+                    tracing::debug!(
+                        error = %compact_error(&e),
+                        "failed to record relay catalog entry"
+                    );
+                }
+                counter!("ingest_nip66_relay_discovery_total").increment(1);
+            }
 
             if is_novel {
                 // New event - NOW pack it (only for novel events)

--- a/crates/pensieve-ingest/src/relay/catalog.rs
+++ b/crates/pensieve-ingest/src/relay/catalog.rs
@@ -4,9 +4,15 @@
 //! probe: supported NIPs, network type, round-trip times, requirements, geohash.
 //! These events arrive through the normal firehose (the relay source subscribes
 //! to all kinds), and this module parses them into [`RelayCatalogEntry`] rows that
-//! the relay manager persists — keyed by `(relay_url, monitor_pubkey)` so multiple
+//! the relay manager persists — keyed by `(relay_id, monitor_pubkey)` so multiple
 //! monitors are aggregated rather than trusted individually (NIP-66 advises against
 //! trusting a single monitor).
+//!
+//! The `d` tag is validated, not trusted: URL-shaped values are normalized and
+//! filtered through the shared relay URL normalizer (so trailing-slash/case
+//! variants collapse and localhost/private/blocked URLs are rejected), and the
+//! NIP-66 alternative of a bare hex pubkey (for relays with no URL) is modeled
+//! explicitly via [`RelayId`]. Anything else is dropped.
 //!
 //! The catalog is the foundation for non-graph relay discovery and dynamic
 //! negentropy targeting (relays advertising NIP-77 via [`RelayCatalogEntry::supports_nip`]).
@@ -18,11 +24,42 @@ pub const KIND_RELAY_DISCOVERY: u16 = 30166;
 /// Kind for NIP-66 relay monitor announcements.
 pub const KIND_RELAY_MONITOR: u16 = 10166;
 
+/// Identifier for a relay from a NIP-66 `d` tag.
+///
+/// NIP-66 says the `d` tag is the relay's normalized URL, or a hex pubkey for
+/// relays not addressable by URL. We model both explicitly so callers can tell a
+/// connectable URL apart from an opaque pubkey id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelayId {
+    /// A normalized relay websocket URL (validated via the shared normalizer).
+    Url(String),
+    /// A 64-char lowercase hex pubkey, for relays without a URL.
+    Pubkey(String),
+}
+
+impl RelayId {
+    /// The underlying string value (normalized URL or hex pubkey).
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Url(s) | Self::Pubkey(s) => s,
+        }
+    }
+
+    /// `"url"` or `"pubkey"` — stored alongside the id so queries can filter to
+    /// connectable URL relays.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Url(_) => "url",
+            Self::Pubkey(_) => "pubkey",
+        }
+    }
+}
+
 /// A relay's characteristics as reported by one monitor's kind-`30166` event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RelayCatalogEntry {
-    /// Normalized relay URL (the `d` tag).
-    pub relay_url: String,
+    /// Relay identifier (normalized URL or hex pubkey), from the `d` tag.
+    pub relay_id: RelayId,
     /// Hex pubkey of the monitor that reported this.
     pub monitor_pubkey: String,
     /// Network type (`clearnet`, `tor`, `i2p`, `loki`), from the `n` tag.
@@ -54,7 +91,8 @@ impl RelayCatalogEntry {
 
 /// Parse a NIP-66 kind-`30166` relay discovery event into a catalog entry.
 ///
-/// Returns `None` if the event is not a relay discovery event or lacks a `d` tag.
+/// Returns `None` if the event is not a relay discovery event, lacks a `d` tag,
+/// or the `d` tag is neither a valid relay URL nor a hex pubkey.
 pub fn parse_relay_discovery(event: &nostr_sdk::Event) -> Option<RelayCatalogEntry> {
     if event.kind.as_u16() != KIND_RELAY_DISCOVERY {
         return None;
@@ -66,6 +104,26 @@ pub fn parse_relay_discovery(event: &nostr_sdk::Event) -> Option<RelayCatalogEnt
     )
 }
 
+/// Classify and validate a `d`-tag value into a [`RelayId`].
+///
+/// URL-shaped values go through the shared relay URL normalizer (rejecting
+/// invalid/blocked/private URLs and collapsing cosmetic variants); otherwise a
+/// 64-char hex string is accepted as a pubkey id. Anything else returns `None`.
+fn classify_relay_id(d: &str) -> Option<RelayId> {
+    if d.starts_with("ws://") || d.starts_with("wss://") {
+        return super::url::normalize_relay_url(d).ok().map(RelayId::Url);
+    }
+    if is_hex64(d) {
+        return Some(RelayId::Pubkey(d.to_ascii_lowercase()));
+    }
+    None
+}
+
+/// Whether `s` is exactly 64 hexadecimal characters (a Nostr pubkey).
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 /// Build a catalog entry from a monitor pubkey, timestamp, and the event's tags.
 ///
 /// Split out from [`parse_relay_discovery`] so the tag logic is unit-testable
@@ -75,7 +133,7 @@ fn build_entry<'a>(
     observed_at: u64,
     tags: impl Iterator<Item = &'a [String]>,
 ) -> Option<RelayCatalogEntry> {
-    let mut relay_url: Option<String> = None;
+    let mut raw_d: Option<String> = None;
     let mut network = None;
     let mut supported_nips = Vec::new();
     let mut requirements = Vec::new();
@@ -92,7 +150,7 @@ fn build_entry<'a>(
         match name {
             "d" => {
                 if let Some(v) = value.filter(|v| !v.is_empty()) {
-                    relay_url = Some(v.to_string());
+                    raw_d = Some(v.to_string());
                 }
             }
             "n" => network = value.map(str::to_string),
@@ -114,8 +172,10 @@ fn build_entry<'a>(
         }
     }
 
+    let relay_id = classify_relay_id(&raw_d?)?;
+
     Some(RelayCatalogEntry {
-        relay_url: relay_url?,
+        relay_id,
         monitor_pubkey,
         network,
         supported_nips,
@@ -148,9 +208,10 @@ mod tests {
     }
 
     #[test]
-    fn parses_a_full_discovery_event() {
+    fn parses_a_full_discovery_event_and_normalizes_url() {
+        // Mixed-case host + trailing slash exercises URL normalization.
         let entry = parse(&[
-            &["d", "wss://some.relay/"],
+            &["d", "wss://Some.Relay/"],
             &["n", "clearnet"],
             &["N", "1"],
             &["N", "77"],
@@ -162,7 +223,8 @@ mod tests {
         ])
         .expect("entry");
 
-        assert_eq!(entry.relay_url, "wss://some.relay/");
+        assert_eq!(entry.relay_id, RelayId::Url("wss://some.relay".to_string()));
+        assert_eq!(entry.relay_id.kind(), "url");
         assert_eq!(entry.monitor_pubkey, "monitor_pk");
         assert_eq!(entry.network.as_deref(), Some("clearnet"));
         assert_eq!(entry.supported_nips, vec!["1", "77"]);
@@ -175,28 +237,55 @@ mod tests {
     }
 
     #[test]
+    fn url_variants_normalize_to_the_same_id() {
+        let a = parse(&[&["d", "wss://Relay.Example.COM/"]]).unwrap();
+        let b = parse(&[&["d", "wss://relay.example.com"]]).unwrap();
+        assert_eq!(a.relay_id, b.relay_id);
+        assert_eq!(
+            a.relay_id,
+            RelayId::Url("wss://relay.example.com".to_string())
+        );
+    }
+
+    #[test]
     fn supports_nip_checks_the_n_tags() {
-        let entry = parse(&[&["d", "wss://r/"], &["N", "77"]]).unwrap();
+        let entry = parse(&[&["d", "wss://relay.example.com"], &["N", "77"]]).unwrap();
         assert!(entry.supports_nip("77")); // negentropy
         assert!(!entry.supports_nip("50"));
     }
 
     #[test]
-    fn missing_d_tag_yields_none() {
+    fn accepts_pubkey_d_tag_for_url_less_relays() {
+        let pk = "a".repeat(64);
+        let entry = parse(&[&["d", &pk.to_uppercase()]]).unwrap();
+        assert_eq!(entry.relay_id, RelayId::Pubkey(pk)); // stored lowercase
+        assert_eq!(entry.relay_id.kind(), "pubkey");
+    }
+
+    #[test]
+    fn rejects_missing_or_empty_d() {
         assert!(parse(&[&["n", "clearnet"], &["N", "1"]]).is_none());
-        assert!(parse(&[&["d"]]).is_none()); // d present but no value
-        assert!(parse(&[&["d", ""]]).is_none()); // empty value
+        assert!(parse(&[&["d"]]).is_none());
+        assert!(parse(&[&["d", ""]]).is_none());
+    }
+
+    #[test]
+    fn rejects_invalid_blocked_and_non_url_ids() {
+        assert!(parse(&[&["d", "wss://localhost:8080"]]).is_none()); // blocked
+        assert!(parse(&[&["d", "http://relay.example.com"]]).is_none()); // not ws
+        assert!(parse(&[&["d", "relay.example.com"]]).is_none()); // no scheme, not hex
+        assert!(parse(&[&["d", "not a url"]]).is_none());
     }
 
     #[test]
     fn bad_rtt_is_ignored() {
-        let entry = parse(&[&["d", "wss://r/"], &["rtt-open", "not-a-number"]]).unwrap();
+        let entry = parse(&[&["d", "wss://relay.example.com"], &["rtt-open", "nope"]]).unwrap();
         assert_eq!(entry.rtt_open, None);
     }
 
     #[test]
     fn alphanumeric_nips_are_preserved() {
-        let entry = parse(&[&["d", "wss://r/"], &["N", "C7"]]).unwrap();
+        let entry = parse(&[&["d", "wss://relay.example.com"], &["N", "C7"]]).unwrap();
         assert!(entry.supports_nip("C7"));
     }
 }

--- a/crates/pensieve-ingest/src/relay/catalog.rs
+++ b/crates/pensieve-ingest/src/relay/catalog.rs
@@ -1,0 +1,202 @@
+//! NIP-66 relay catalog consumer.
+//!
+//! Monitors publish kind-`30166` "relay discovery" events describing relays they
+//! probe: supported NIPs, network type, round-trip times, requirements, geohash.
+//! These events arrive through the normal firehose (the relay source subscribes
+//! to all kinds), and this module parses them into [`RelayCatalogEntry`] rows that
+//! the relay manager persists — keyed by `(relay_url, monitor_pubkey)` so multiple
+//! monitors are aggregated rather than trusted individually (NIP-66 advises against
+//! trusting a single monitor).
+//!
+//! The catalog is the foundation for non-graph relay discovery and dynamic
+//! negentropy targeting (relays advertising NIP-77 via [`RelayCatalogEntry::supports_nip`]).
+//!
+//! See <https://github.com/nostr-protocol/nips/blob/master/66.md>.
+
+/// Kind for NIP-66 relay discovery events.
+pub const KIND_RELAY_DISCOVERY: u16 = 30166;
+/// Kind for NIP-66 relay monitor announcements.
+pub const KIND_RELAY_MONITOR: u16 = 10166;
+
+/// A relay's characteristics as reported by one monitor's kind-`30166` event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelayCatalogEntry {
+    /// Normalized relay URL (the `d` tag).
+    pub relay_url: String,
+    /// Hex pubkey of the monitor that reported this.
+    pub monitor_pubkey: String,
+    /// Network type (`clearnet`, `tor`, `i2p`, `loki`), from the `n` tag.
+    pub network: Option<String>,
+    /// NIPs the relay supports, from repeated `N` tags. Kept as raw strings since
+    /// some NIP identifiers are alphanumeric (e.g. `C7`).
+    pub supported_nips: Vec<String>,
+    /// Relay requirements (`auth`, `payment`, ...; negated values are prefixed `!`),
+    /// from repeated `R` tags.
+    pub requirements: Vec<String>,
+    /// Round-trip time in ms for opening a connection (`rtt-open`).
+    pub rtt_open: Option<u32>,
+    /// Round-trip time in ms for a read (`rtt-read`).
+    pub rtt_read: Option<u32>,
+    /// Round-trip time in ms for a write (`rtt-write`).
+    pub rtt_write: Option<u32>,
+    /// NIP-52 geohash, from the `g` tag.
+    pub geohash: Option<String>,
+    /// The event's `created_at` — when the monitor observed the relay.
+    pub observed_at: u64,
+}
+
+impl RelayCatalogEntry {
+    /// Whether the relay advertises support for the given NIP (e.g. `"77"` for negentropy).
+    pub fn supports_nip(&self, nip: &str) -> bool {
+        self.supported_nips.iter().any(|n| n == nip)
+    }
+}
+
+/// Parse a NIP-66 kind-`30166` relay discovery event into a catalog entry.
+///
+/// Returns `None` if the event is not a relay discovery event or lacks a `d` tag.
+pub fn parse_relay_discovery(event: &nostr_sdk::Event) -> Option<RelayCatalogEntry> {
+    if event.kind.as_u16() != KIND_RELAY_DISCOVERY {
+        return None;
+    }
+    build_entry(
+        event.pubkey.to_hex(),
+        event.created_at.as_secs(),
+        event.tags.iter().map(|t| t.as_slice()),
+    )
+}
+
+/// Build a catalog entry from a monitor pubkey, timestamp, and the event's tags.
+///
+/// Split out from [`parse_relay_discovery`] so the tag logic is unit-testable
+/// without constructing a signed event.
+fn build_entry<'a>(
+    monitor_pubkey: String,
+    observed_at: u64,
+    tags: impl Iterator<Item = &'a [String]>,
+) -> Option<RelayCatalogEntry> {
+    let mut relay_url: Option<String> = None;
+    let mut network = None;
+    let mut supported_nips = Vec::new();
+    let mut requirements = Vec::new();
+    let mut rtt_open = None;
+    let mut rtt_read = None;
+    let mut rtt_write = None;
+    let mut geohash = None;
+
+    for parts in tags {
+        let Some(name) = parts.first().map(String::as_str) else {
+            continue;
+        };
+        let value = parts.get(1).map(String::as_str);
+        match name {
+            "d" => {
+                if let Some(v) = value.filter(|v| !v.is_empty()) {
+                    relay_url = Some(v.to_string());
+                }
+            }
+            "n" => network = value.map(str::to_string),
+            "N" => {
+                if let Some(v) = value {
+                    supported_nips.push(v.to_string());
+                }
+            }
+            "R" => {
+                if let Some(v) = value {
+                    requirements.push(v.to_string());
+                }
+            }
+            "rtt-open" => rtt_open = value.and_then(|v| v.parse().ok()),
+            "rtt-read" => rtt_read = value.and_then(|v| v.parse().ok()),
+            "rtt-write" => rtt_write = value.and_then(|v| v.parse().ok()),
+            "g" => geohash = value.map(str::to_string),
+            _ => {}
+        }
+    }
+
+    Some(RelayCatalogEntry {
+        relay_url: relay_url?,
+        monitor_pubkey,
+        network,
+        supported_nips,
+        requirements,
+        rtt_open,
+        rtt_read,
+        rtt_write,
+        geohash,
+        observed_at,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(rows: &[&[&str]]) -> Vec<Vec<String>> {
+        rows.iter()
+            .map(|r| r.iter().map(|s| s.to_string()).collect())
+            .collect()
+    }
+
+    fn parse(rows: &[&[&str]]) -> Option<RelayCatalogEntry> {
+        let t = tags(rows);
+        build_entry(
+            "monitor_pk".to_string(),
+            1_700_000_000,
+            t.iter().map(Vec::as_slice),
+        )
+    }
+
+    #[test]
+    fn parses_a_full_discovery_event() {
+        let entry = parse(&[
+            &["d", "wss://some.relay/"],
+            &["n", "clearnet"],
+            &["N", "1"],
+            &["N", "77"],
+            &["R", "!payment"],
+            &["R", "auth"],
+            &["g", "ww8p1r4t8"],
+            &["rtt-open", "234"],
+            &["rtt-read", "12"],
+        ])
+        .expect("entry");
+
+        assert_eq!(entry.relay_url, "wss://some.relay/");
+        assert_eq!(entry.monitor_pubkey, "monitor_pk");
+        assert_eq!(entry.network.as_deref(), Some("clearnet"));
+        assert_eq!(entry.supported_nips, vec!["1", "77"]);
+        assert_eq!(entry.requirements, vec!["!payment", "auth"]);
+        assert_eq!(entry.geohash.as_deref(), Some("ww8p1r4t8"));
+        assert_eq!(entry.rtt_open, Some(234));
+        assert_eq!(entry.rtt_read, Some(12));
+        assert_eq!(entry.rtt_write, None);
+        assert_eq!(entry.observed_at, 1_700_000_000);
+    }
+
+    #[test]
+    fn supports_nip_checks_the_n_tags() {
+        let entry = parse(&[&["d", "wss://r/"], &["N", "77"]]).unwrap();
+        assert!(entry.supports_nip("77")); // negentropy
+        assert!(!entry.supports_nip("50"));
+    }
+
+    #[test]
+    fn missing_d_tag_yields_none() {
+        assert!(parse(&[&["n", "clearnet"], &["N", "1"]]).is_none());
+        assert!(parse(&[&["d"]]).is_none()); // d present but no value
+        assert!(parse(&[&["d", ""]]).is_none()); // empty value
+    }
+
+    #[test]
+    fn bad_rtt_is_ignored() {
+        let entry = parse(&[&["d", "wss://r/"], &["rtt-open", "not-a-number"]]).unwrap();
+        assert_eq!(entry.rtt_open, None);
+    }
+
+    #[test]
+    fn alphanumeric_nips_are_preserved() {
+        let entry = parse(&[&["d", "wss://r/"], &["N", "C7"]]).unwrap();
+        assert!(entry.supports_nip("C7"));
+    }
+}

--- a/crates/pensieve-ingest/src/relay/manager.rs
+++ b/crates/pensieve-ingest/src/relay/manager.rs
@@ -184,6 +184,50 @@ impl RelayManager {
         Ok(())
     }
 
+    /// Upsert a NIP-66 relay catalog entry (one row per relay + reporting monitor).
+    ///
+    /// Older observations never overwrite newer ones for the same (relay, monitor).
+    pub fn record_catalog_entry(&self, entry: &super::catalog::RelayCatalogEntry) -> Result<()> {
+        let now = Self::unix_now();
+        let supported_nips = entry.supported_nips.join(",");
+        let requirements = entry.requirements.join(",");
+        let conn = self.conn.lock();
+
+        conn.execute(
+            "INSERT INTO relay_catalog
+                (relay_url, monitor_pubkey, network, supported_nips, requirements,
+                 rtt_open, rtt_read, rtt_write, geohash, observed_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(relay_url, monitor_pubkey) DO UPDATE SET
+                network = excluded.network,
+                supported_nips = excluded.supported_nips,
+                requirements = excluded.requirements,
+                rtt_open = excluded.rtt_open,
+                rtt_read = excluded.rtt_read,
+                rtt_write = excluded.rtt_write,
+                geohash = excluded.geohash,
+                observed_at = excluded.observed_at,
+                updated_at = excluded.updated_at
+             WHERE excluded.observed_at >= relay_catalog.observed_at",
+            rusqlite::params![
+                entry.relay_url,
+                entry.monitor_pubkey,
+                entry.network,
+                supported_nips,
+                requirements,
+                entry.rtt_open,
+                entry.rtt_read,
+                entry.rtt_write,
+                entry.geohash,
+                entry.observed_at as i64,
+                now,
+            ],
+        )
+        .map_err(|e| Error::Database(format!("Failed to record catalog entry: {}", e)))?;
+
+        Ok(())
+    }
+
     /// Import relays from a JSON discovery results file.
     ///
     /// Expected format: JSON object with `functioning_relays` array of URL strings.

--- a/crates/pensieve-ingest/src/relay/manager.rs
+++ b/crates/pensieve-ingest/src/relay/manager.rs
@@ -187,18 +187,23 @@ impl RelayManager {
     /// Upsert a NIP-66 relay catalog entry (one row per relay + reporting monitor).
     ///
     /// Older observations never overwrite newer ones for the same (relay, monitor).
+    /// `supported_nips`/`requirements` are stored comma-joined for now; a child
+    /// table or JSON would age better once we add exact NIP-match queries.
     pub fn record_catalog_entry(&self, entry: &super::catalog::RelayCatalogEntry) -> Result<()> {
         let now = Self::unix_now();
+        let relay_id = entry.relay_id.as_str();
+        let relay_id_kind = entry.relay_id.kind();
         let supported_nips = entry.supported_nips.join(",");
         let requirements = entry.requirements.join(",");
         let conn = self.conn.lock();
 
         conn.execute(
             "INSERT INTO relay_catalog
-                (relay_url, monitor_pubkey, network, supported_nips, requirements,
-                 rtt_open, rtt_read, rtt_write, geohash, observed_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(relay_url, monitor_pubkey) DO UPDATE SET
+                (relay_id, relay_id_kind, monitor_pubkey, network, supported_nips,
+                 requirements, rtt_open, rtt_read, rtt_write, geohash, observed_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(relay_id, monitor_pubkey) DO UPDATE SET
+                relay_id_kind = excluded.relay_id_kind,
                 network = excluded.network,
                 supported_nips = excluded.supported_nips,
                 requirements = excluded.requirements,
@@ -210,7 +215,8 @@ impl RelayManager {
                 updated_at = excluded.updated_at
              WHERE excluded.observed_at >= relay_catalog.observed_at",
             rusqlite::params![
-                entry.relay_url,
+                relay_id,
+                relay_id_kind,
                 entry.monitor_pubkey,
                 entry.network,
                 supported_nips,

--- a/crates/pensieve-ingest/src/relay/mod.rs
+++ b/crates/pensieve-ingest/src/relay/mod.rs
@@ -51,7 +51,7 @@ mod scoring;
 pub mod url;
 
 pub use catalog::{
-    KIND_RELAY_DISCOVERY, KIND_RELAY_MONITOR, RelayCatalogEntry, parse_relay_discovery,
+    KIND_RELAY_DISCOVERY, KIND_RELAY_MONITOR, RelayCatalogEntry, RelayId, parse_relay_discovery,
 };
 pub use connection_guard::{ConnectionGuard, ConnectionGuardConfig, RejectionReason};
 pub use manager::{AggregateRelayStats, OptimizationSuggestions, RelayManager, RelayManagerConfig};

--- a/crates/pensieve-ingest/src/relay/mod.rs
+++ b/crates/pensieve-ingest/src/relay/mod.rs
@@ -43,12 +43,16 @@
 //! let (disconnect, connect) = manager.get_optimization_suggestions(&connected_urls)?;
 //! ```
 
+mod catalog;
 pub mod connection_guard;
 mod manager;
 mod schema;
 mod scoring;
 pub mod url;
 
+pub use catalog::{
+    KIND_RELAY_DISCOVERY, KIND_RELAY_MONITOR, RelayCatalogEntry, parse_relay_discovery,
+};
 pub use connection_guard::{ConnectionGuard, ConnectionGuardConfig, RejectionReason};
 pub use manager::{AggregateRelayStats, OptimizationSuggestions, RelayManager, RelayManagerConfig};
 pub use schema::{RelayStatus, RelayTier};

--- a/crates/pensieve-ingest/src/relay/schema.rs
+++ b/crates/pensieve-ingest/src/relay/schema.rs
@@ -6,7 +6,7 @@
 use rusqlite::{Connection, Result};
 
 /// Current schema version. Increment when making breaking changes.
-pub const SCHEMA_VERSION: i32 = 2;
+pub const SCHEMA_VERSION: i32 = 3;
 
 /// Initialize the database schema.
 ///
@@ -120,6 +120,23 @@ fn create_tables(conn: &Connection) -> Result<()> {
             value INTEGER NOT NULL,
             updated_at INTEGER NOT NULL
         );
+
+        -- NIP-66 relay catalog (one row per relay + reporting monitor)
+        CREATE TABLE IF NOT EXISTS relay_catalog (
+            relay_url TEXT NOT NULL,
+            monitor_pubkey TEXT NOT NULL,
+            network TEXT,
+            supported_nips TEXT,
+            requirements TEXT,
+            rtt_open INTEGER,
+            rtt_read INTEGER,
+            rtt_write INTEGER,
+            geohash TEXT,
+            observed_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (relay_url, monitor_pubkey)
+        );
+        CREATE INDEX IF NOT EXISTS idx_relay_catalog_url ON relay_catalog(relay_url);
         "#,
     )?;
 
@@ -131,6 +148,9 @@ fn migrate(conn: &Connection, from: i32, to: i32) -> Result<()> {
     for version in from..to {
         if version == 1 {
             migrate_v1_to_v2(conn)?;
+        }
+        if version == 2 {
+            migrate_v2_to_v3(conn)?;
         }
     }
     set_schema_version(conn, to)?;
@@ -146,6 +166,30 @@ fn migrate_v1_to_v2(conn: &Connection) -> Result<()> {
             value INTEGER NOT NULL,
             updated_at INTEGER NOT NULL
         );
+        "#,
+    )?;
+    Ok(())
+}
+
+/// Migrate from v2 to v3: add the NIP-66 relay_catalog table.
+fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS relay_catalog (
+            relay_url TEXT NOT NULL,
+            monitor_pubkey TEXT NOT NULL,
+            network TEXT,
+            supported_nips TEXT,
+            requirements TEXT,
+            rtt_open INTEGER,
+            rtt_read INTEGER,
+            rtt_write INTEGER,
+            geohash TEXT,
+            observed_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (relay_url, monitor_pubkey)
+        );
+        CREATE INDEX IF NOT EXISTS idx_relay_catalog_url ON relay_catalog(relay_url);
         "#,
     )?;
     Ok(())
@@ -247,6 +291,7 @@ mod tests {
         assert!(tables.contains(&"relay_stats_hourly".to_string()));
         assert!(tables.contains(&"relay_stats_daily".to_string()));
         assert!(tables.contains(&"relay_scores".to_string()));
+        assert!(tables.contains(&"relay_catalog".to_string()));
     }
 
     #[test]

--- a/crates/pensieve-ingest/src/relay/schema.rs
+++ b/crates/pensieve-ingest/src/relay/schema.rs
@@ -123,7 +123,8 @@ fn create_tables(conn: &Connection) -> Result<()> {
 
         -- NIP-66 relay catalog (one row per relay + reporting monitor)
         CREATE TABLE IF NOT EXISTS relay_catalog (
-            relay_url TEXT NOT NULL,
+            relay_id TEXT NOT NULL,
+            relay_id_kind TEXT NOT NULL,
             monitor_pubkey TEXT NOT NULL,
             network TEXT,
             supported_nips TEXT,
@@ -134,9 +135,9 @@ fn create_tables(conn: &Connection) -> Result<()> {
             geohash TEXT,
             observed_at INTEGER NOT NULL,
             updated_at INTEGER NOT NULL,
-            PRIMARY KEY (relay_url, monitor_pubkey)
+            PRIMARY KEY (relay_id, monitor_pubkey)
         );
-        CREATE INDEX IF NOT EXISTS idx_relay_catalog_url ON relay_catalog(relay_url);
+        CREATE INDEX IF NOT EXISTS idx_relay_catalog_relay_id ON relay_catalog(relay_id);
         "#,
     )?;
 
@@ -176,7 +177,8 @@ fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         r#"
         CREATE TABLE IF NOT EXISTS relay_catalog (
-            relay_url TEXT NOT NULL,
+            relay_id TEXT NOT NULL,
+            relay_id_kind TEXT NOT NULL,
             monitor_pubkey TEXT NOT NULL,
             network TEXT,
             supported_nips TEXT,
@@ -187,9 +189,9 @@ fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
             geohash TEXT,
             observed_at INTEGER NOT NULL,
             updated_at INTEGER NOT NULL,
-            PRIMARY KEY (relay_url, monitor_pubkey)
+            PRIMARY KEY (relay_id, monitor_pubkey)
         );
-        CREATE INDEX IF NOT EXISTS idx_relay_catalog_url ON relay_catalog(relay_url);
+        CREATE INDEX IF NOT EXISTS idx_relay_catalog_relay_id ON relay_catalog(relay_id);
         "#,
     )?;
     Ok(())


### PR DESCRIPTION
## Summary

First slice of the **NIP-66 catalog consumer** (migration plan P1). Monitors publish kind-`30166` "relay discovery" events describing relays they probe (supported NIPs, network, RTT, requirements, geohash). These already arrive through the all-kinds firehose, so this adds a consumer that parses and persists them.

- **`relay/catalog.rs`** — `RelayCatalogEntry` + `parse_relay_discovery` (pure, 5 unit tests). NIPs are kept as raw strings (some are alphanumeric, e.g. `C7`); `supports_nip("77")` is the hook for dynamic negentropy targeting.
- **schema v3** — `relay_catalog` table (PK `(relay_url, monitor_pubkey)` to aggregate across monitors, per NIP-66's "don't trust a single monitor") + migration.
- **`RelayManager::record_catalog_entry`** — upsert where newer observations win.
- **Live handler** dispatches 30166 events; new `ingest_nip66_relay_discovery_total` counter.

## Why
Foundation for non-graph relay discovery and dynamic negentropy targeting — the collection-coverage track of the migration.

## Follow-ups (next slices)
- Ensure connectivity to NIP-66 monitor relays (so 30166 reliably arrives), including nostr.watch.
- Parse kind-`10166` monitor announcements (to weight/trust monitors).
- Feed the catalog into the connection optimizer (auto-register discovered relays) and negentropy target selection (relays advertising NIP-77).
- Add the catalog-coverage metric (connected / reconciled vs known).

## Test plan
- `just precommit` green (fmt, clippy `-D warnings`, 80 lib tests incl. 5 new catalog tests + a schema assertion).

## Stacking
Based on #24 (builds on its coverage metrics block + `main.rs` handler changes). GitHub will retarget this to `master` once #24 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
