### PR TITLE
ops: pin Compose project name + ingester open-file limit (cutover fixes)

### DIFF
--- a/ops/production/compose.yml
+++ b/ops/production/compose.yml
@@ -11,6 +11,13 @@
 # Start Rust services:   sudo systemctl start pensieve-api pensieve-ingest
 # Stop Rust services:    sudo systemctl stop pensieve-api pensieve-ingest
 
+# Pin the Compose project name so every invocation (systemd, justfile, manual)
+# uses the same project/volumes/network regardless of the directory name. Without
+# this, Compose infers the project from the directory (ops/production -> "production"),
+# which orphans the existing pensieve-deploy_* volumes and conflicts on container
+# names. Kept in sync with --project-name in ops/systemd/pensieve.service.
+name: pensieve-deploy
+
 services:
   # ═══════════════════════════════════════════════════════════════════════════
   # Caddy - Reverse Proxy with Auto-HTTPS

--- a/ops/systemd/pensieve-ingest.service
+++ b/ops/systemd/pensieve-ingest.service
@@ -38,6 +38,10 @@ ExecStart=/home/pensieve/pensieve/target/release/pensieve-ingest \
 Restart=always
 RestartSec=10
 
+# Open-file limit: the ingester holds many concurrent relay sockets; the systemd
+# default caused "Too many open files" (notably during shutdown).
+LimitNOFILE=524288
+
 # Logging: the binary defaults to info with noisy upstream crates suppressed.
 # To override:  systemctl edit pensieve-ingest  →  Environment=RUST_LOG=debug
 # Environment=RUST_LOG=info

--- a/ops/systemd/pensieve.service
+++ b/ops/systemd/pensieve.service
@@ -12,8 +12,10 @@ WorkingDirectory=/home/pensieve/pensieve/ops/production
 
 # Start docker compose (ClickHouse, Grafana, Prometheus, Caddy).
 # --env-file points at the production secrets, which live outside the repo tree.
-ExecStart=/usr/bin/docker compose --env-file /etc/pensieve/pensieve.env up
-ExecStop=/usr/bin/docker compose --env-file /etc/pensieve/pensieve.env down
+# --project-name pins the project to pensieve-deploy (also set via `name:` in
+# compose.yml) so the ops/ rename does not orphan the existing volumes/network.
+ExecStart=/usr/bin/docker compose --project-name pensieve-deploy --env-file /etc/pensieve/pensieve.env up
+ExecStop=/usr/bin/docker compose --project-name pensieve-deploy --env-file /etc/pensieve/pensieve.env down
 
 # Restart policy
 Restart=always


### PR DESCRIPTION
## Summary

Upstreams the two fixes the sysadmin applied by hand during the `ops/` cutover (so the repo matches the box and future deploys don't reintroduce them), and closes a gap their unit-only patch missed.

- **Pin the Compose project to `pensieve-deploy`.** The `pensieve-deploy/` → `ops/production/` rename made Compose infer the project name `production` from the directory, which orphaned the existing `pensieve-deploy_*` data volumes (the empty `production_*` volumes seen during cutover) and conflicted on `container_name`. Fixed with a top-level `name: pensieve-deploy` in `compose.yml` **and** `--project-name pensieve-deploy` in `pensieve.service`. The compose `name:` covers *all* invocations — systemd, the `justfile prod-grafana-restart` recipe, and manual `docker compose` — not just the unit.
- **Raise `pensieve-ingest` `LimitNOFILE` to 524288.** The systemd default caused `Too many open files` (the ingester holds many concurrent relay sockets, notably during shutdown).

Verified: `docker compose config` resolves project name = `pensieve-deploy`; compose validates.

## For the box (after merge)

These behaviors are already live (applied by hand during cutover). To converge repo↔box:

```bash
cd ~/pensieve
git checkout ops/systemd/pensieve.service ops/systemd/pensieve-ingest.service  # drop local hand-patches
git pull origin master
sudo install -m 644 ops/systemd/*.service /etc/systemd/system/ && sudo systemctl daemon-reload
# no restart strictly required — installed units already match the deployed behavior
```

Then `git stash drop` the `pre-ops-cutover-local-prod-config` breadcrumb once happy.

## Not in this PR (box-side housekeeping, safe whenever)

- Remove the empty `production_*` Docker volumes left by the failed first Compose attempt.
- Delete the leftover `~/pensieve/pensieve-deploy/.env` (now unused; secrets live in `/etc/pensieve/pensieve.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
