### PR TITLE
NIP-66 catalog-coverage metrics + monitor-relay connectivity

### DIFF
--- a/crates/pensieve-core/src/metrics.rs
+++ b/crates/pensieve-core/src/metrics.rs
@@ -212,6 +212,18 @@ fn register_common_metrics() {
         "ingest_nip66_relay_discovery_errors_total",
         "NIP-66 relay discovery events that failed to record into the catalog"
     );
+    describe_gauge!(
+        "ingest_nip66_catalog_relays",
+        "Distinct relays known in the NIP-66 catalog"
+    );
+    describe_gauge!(
+        "ingest_nip66_catalog_nip77_relays",
+        "Distinct URL relays in the catalog advertising NIP-77 (negentropy-capable)"
+    );
+    describe_gauge!(
+        "ingest_nip66_catalog_monitors",
+        "Distinct NIP-66 monitors reporting into the catalog"
+    );
 
     // =========================================================================
     // Relay Manager Metrics

--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -148,6 +148,13 @@ struct Args {
     #[arg(long)]
     import_discovered_json: Option<PathBuf>,
 
+    /// Relays that carry NIP-66 monitor data (kind 30166/10166), comma-separated.
+    ///
+    /// Registered as seed-tier (always-connect) so the relay catalog reliably
+    /// fills. Point at a NIP-66 monitor's relay(s), e.g. nostr.watch.
+    #[arg(long, value_delimiter = ',')]
+    nip66_monitor_relays: Option<Vec<String>>,
+
     /// Disable relay discovery via NIP-65
     #[arg(long)]
     no_discovery: bool,
@@ -322,7 +329,7 @@ async fn main() -> Result<()> {
 
     // Load seed relays (tier=seed, protected from eviction)
     // Priority: CLI args > seed file > hardcoded defaults
-    let seed_relays = if let Some(relays) = args.seed_relays.clone() {
+    let mut seed_relays = if let Some(relays) = args.seed_relays.clone() {
         tracing::info!(
             relay_count = relays.len(),
             "using seed relays from CLI arguments"
@@ -355,6 +362,24 @@ async fn main() -> Result<()> {
         tracing::info!("Using default seed relays (no seed file found)");
         default_seed_relays()
     };
+
+    // NIP-66 monitor relays: always-connect (seed tier) so the relay catalog fills.
+    if let Some(monitors) = args.nip66_monitor_relays.clone() {
+        let mut added = 0usize;
+        for m in monitors {
+            let Some(normalized) = normalize_relay_url(&m).ok() else {
+                tracing::warn!(relay = %m, "skipping invalid NIP-66 monitor relay");
+                continue;
+            };
+            if !seed_relays.contains(&normalized) {
+                seed_relays.push(normalized);
+                added += 1;
+            }
+        }
+        if added > 0 {
+            tracing::info!(count = added, "added NIP-66 monitor relays (seed tier)");
+        }
+    }
 
     // Register seeds with tier=seed (protected, score floor 0.5)
     relay_manager.register_seed_relays(&seed_relays)?;
@@ -619,6 +644,13 @@ async fn main() -> Result<()> {
                 gauge!("relay_manager_events_novel_1h").set(agg_stats.events_novel_1h as f64);
                 gauge!("relay_manager_events_duplicate_1h")
                     .set(agg_stats.events_duplicate_1h as f64);
+            }
+
+            // NIP-66 catalog coverage: known relays vs NIP-77-capable vs monitors.
+            if let Ok((known, nip77, monitors)) = metrics_relay_manager.catalog_stats() {
+                gauge!("ingest_nip66_catalog_relays").set(known as f64);
+                gauge!("ingest_nip66_catalog_nip77_relays").set(nip77 as f64);
+                gauge!("ingest_nip66_catalog_monitors").set(monitors as f64);
             }
         }
 

--- a/crates/pensieve-ingest/src/relay/manager.rs
+++ b/crates/pensieve-ingest/src/relay/manager.rs
@@ -234,6 +234,42 @@ impl RelayManager {
         Ok(())
     }
 
+    /// Catalog-coverage counts for metrics: `(known, nip77_url, monitors)`.
+    ///
+    /// `known` = distinct relay ids in the catalog; `nip77_url` = distinct URL relays
+    /// advertising NIP-77 (negentropy-capable); `monitors` = distinct reporting monitors.
+    pub fn catalog_stats(&self) -> Result<(u64, u64, u64)> {
+        let conn = self.conn.lock();
+
+        let known: i64 = conn
+            .query_row(
+                "SELECT COUNT(DISTINCT relay_id) FROM relay_catalog",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+
+        // supported_nips is comma-joined; wrap in commas for an exact membership match.
+        let nip77_url: i64 = conn
+            .query_row(
+                "SELECT COUNT(DISTINCT relay_id) FROM relay_catalog \
+                 WHERE relay_id_kind = 'url' AND (',' || supported_nips || ',') LIKE '%,77,%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+
+        let monitors: i64 = conn
+            .query_row(
+                "SELECT COUNT(DISTINCT monitor_pubkey) FROM relay_catalog",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+
+        Ok((known as u64, nip77_url as u64, monitors as u64))
+    }
+
     /// Import relays from a JSON discovery results file.
     ///
     /// Expected format: JSON object with `functioning_relays` array of URL strings.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -134,12 +134,12 @@ Make aggressive collection safe *before* doing it, and lay the rails for Track B
 
 ### P1 — Collection & coverage  *(Track A; additive; priority)*
 
-- [ ] **Coverage instrumentation first.** Two metrics on existing Grafana, measured at a
+- [x] **Coverage instrumentation.** Two metrics on existing Grafana, measured at a
       baseline before anything changes:
   - *Reference-coverage:* sample event ids referenced in `e`/`a`/`q` tags of events we
     have, check RocksDB membership → `have / referenced` %.
   - *Catalog-coverage:* `connected / reconciled / known` relays (known = from NIP-66).
-- [ ] **NIP-66 catalog consumer.** Subscribe to kind **10166** (monitor announcements →
+- [x] **NIP-66 catalog consumer (first slice).** Subscribe to kind **10166** (monitor announcements →
       discover monitors + frequency) and kind **30166** (relay discovery) from a trusted
       monitor set (nostr.watch primary). Persist a `relay_catalog`:
       URL (`d`), supported NIPs (`N`), network (`n`), RTT (`rtt-*`), requirements (`R`),
@@ -247,12 +247,15 @@ The diff harness (seeded in P0) is what makes cutovers trustworthy:
 
 ## 8. Status tracker
 
-- **P0 Foundation** — in progress (disk relief done; bucket/harness/backups pending)
-- **P1 Collection & coverage** — not started (next up)
+- **P0 Foundation** — in progress (disk relief done; object-storage bucket / verify harness / backups pending)
+- **P1 Collection & coverage** — in progress (reference-coverage ✅, NIP-66 catalog first slice ✅, catalog-coverage metrics ✅; dynamic negentropy targeting + windowed backfill pending)
 - **P2 Parquet archive** — not started
 - **P3 New analytics** — not started
 - **P4 Reader cutover** — not started
 - **P5 Retire & reclaim** — not started
+
+Also done (operational, not a plan phase): `pensieve-deploy/` → `ops/` restructure with
+secrets in `/etc/pensieve/pensieve.env`; production box cut over to the new layout.
 
 ---
 


### PR DESCRIPTION
## Summary

Next Track A / P1 slice, building on the merged NIP-66 catalog (#26). Makes the catalog fill reliably and become visible on Grafana — the "measure before acting" step ahead of dynamic negentropy targeting.

- **`--nip66-monitor-relays` flag** — registers the relays that carry NIP-66 monitor events (kind 30166/10166, e.g. nostr.watch) as **seed-tier** (always-connect), so the catalog fills instead of relying on whatever the broad firehose happens to receive. Default empty — set it to your monitor relay(s).
- **Catalog-coverage gauges** (`RelayManager::catalog_stats`), emitted from the periodic metrics task:
  - `ingest_nip66_catalog_relays` — known relays
  - `ingest_nip66_catalog_nip77_relays` — URL relays advertising NIP-77 (negentropy-capable)
  - `ingest_nip66_catalog_monitors` — distinct reporting monitors

  With the existing `relay_manager_active_relays` (connected), this gives the **known vs connected** coverage picture. `reconciled` lands with dynamic targeting.
- **`docs/migration-plan.md` §8** bumped to reflect P1 progress.

## Deploy note
Set `--nip66-monitor-relays wss://...` on the ingester to the NIP-66 monitor relay(s) you want (nostr.watch's monitor relay is the obvious one). Then watch `ingest_nip66_catalog_*` climb — if they stay flat, the firehose isn't seeing kind-30166 and this flag is what fixes it.

## Test plan
- `just precommit` green (fmt, clippy `-D warnings`, tests).
- After deploy: `ingest_nip66_catalog_relays > 0` confirms the catalog is filling; `ingest_nip66_catalog_nip77_relays` is the pool dynamic negentropy targeting will draw from next.

## Next
Dynamic negentropy targeting: select NIP-77 URL relays from the catalog (retire the hardcoded list / drop Primal) — reuses the `catalog_stats` query surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
