### PR TITLE
Default --nip66-monitor-relays to wss://relay.nostr.watch

### DIFF
--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -151,9 +151,10 @@ struct Args {
     /// Relays that carry NIP-66 monitor data (kind 30166/10166), comma-separated.
     ///
     /// Registered as seed-tier (always-connect) so the relay catalog reliably
-    /// fills. Point at a NIP-66 monitor's relay(s), e.g. nostr.watch.
-    #[arg(long, value_delimiter = ',')]
-    nip66_monitor_relays: Option<Vec<String>>,
+    /// fills. Defaults to nostr.watch's monitor relay (verified to publish the
+    /// NIP-66 kinds); override with your own comma-separated list.
+    #[arg(long, value_delimiter = ',', default_value = "wss://relay.nostr.watch")]
+    nip66_monitor_relays: Vec<String>,
 
     /// Disable relay discovery via NIP-65
     #[arg(long)]
@@ -364,21 +365,22 @@ async fn main() -> Result<()> {
     };
 
     // NIP-66 monitor relays: always-connect (seed tier) so the relay catalog fills.
-    if let Some(monitors) = args.nip66_monitor_relays.clone() {
-        let mut added = 0usize;
-        for m in monitors {
-            let Some(normalized) = normalize_relay_url(&m).ok() else {
-                tracing::warn!(relay = %m, "skipping invalid NIP-66 monitor relay");
-                continue;
-            };
-            if !seed_relays.contains(&normalized) {
-                seed_relays.push(normalized);
-                added += 1;
-            }
+    let mut monitor_added = 0usize;
+    for m in &args.nip66_monitor_relays {
+        let Some(normalized) = normalize_relay_url(m).ok() else {
+            tracing::warn!(relay = %m, "skipping invalid NIP-66 monitor relay");
+            continue;
+        };
+        if !seed_relays.contains(&normalized) {
+            seed_relays.push(normalized);
+            monitor_added += 1;
         }
-        if added > 0 {
-            tracing::info!(count = added, "added NIP-66 monitor relays (seed tier)");
-        }
+    }
+    if monitor_added > 0 {
+        tracing::info!(
+            count = monitor_added,
+            "added NIP-66 monitor relays (seed tier)"
+        );
     }
 
     // Register seeds with tier=seed (protected, score floor 0.5)


### PR DESCRIPTION
## Summary

Production validated `wss://relay.nostr.watch` as the NIP-66 monitor relay: adding it as a monitor seed jumped the catalog from **195/70** to **1193 known / 350 NIP-77-capable** relays. The broad firehose alone was *not* reliably receiving kind-30166 after a restart, so the `--nip66-monitor-relays` lever from #28 was the fix.

This bakes `wss://relay.nostr.watch` in as the **default** for `--nip66-monitor-relays`, so:
- the catalog fills out of the box on any deployment, and
- the production box's local seed edit becomes declarative — a future `ops/systemd` reinstall can't silently clobber it.

The flag is now a non-optional `Vec<String>` with a default; override with your own comma-separated list. `just precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
