### PR TITLE
Make live Parquet shadow bootstrap safe

### DIFF
--- a/crates/pensieve-ingest/Cargo.toml
+++ b/crates/pensieve-ingest/Cargo.toml
@@ -84,7 +84,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 
 # CLI
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.4", features = ["derive", "env"] }
 
 # Signals
 ctrlc.workspace = true

--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -139,61 +139,120 @@ struct Args {
     no_compress: bool,
 
     /// Publish sealed notepack segments to an immutable local Parquet shadow lake.
-    #[arg(long, conflicts_with = "parquet_shadow_s3_bucket")]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_LAKE_DIR",
+        conflicts_with = "parquet_shadow_s3_bucket"
+    )]
     parquet_shadow_lake_dir: Option<PathBuf>,
 
     /// Publish sealed notepack segments to this S3-compatible Parquet shadow bucket.
-    #[arg(long, conflicts_with = "parquet_shadow_lake_dir")]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_S3_BUCKET",
+        conflicts_with = "parquet_shadow_lake_dir"
+    )]
     parquet_shadow_s3_bucket: Option<String>,
 
     /// AWS region override for the Parquet shadow S3 target.
-    #[arg(long, requires = "parquet_shadow_s3_bucket")]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_S3_REGION",
+        requires = "parquet_shadow_s3_bucket"
+    )]
     parquet_shadow_s3_region: Option<String>,
 
     /// Endpoint URL for an S3-compatible Parquet shadow target.
-    #[arg(long, requires = "parquet_shadow_s3_bucket")]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_S3_ENDPOINT_URL",
+        requires = "parquet_shadow_s3_bucket"
+    )]
     parquet_shadow_s3_endpoint_url: Option<String>,
 
     /// Use path-style bucket addressing for the Parquet shadow S3 target.
-    #[arg(long, requires = "parquet_shadow_s3_bucket")]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_S3_FORCE_PATH_STYLE",
+        requires = "parquet_shadow_s3_bucket"
+    )]
     parquet_shadow_s3_force_path_style: bool,
 
     /// SQLite publication journal for the Parquet shadow.
     ///
     /// Defaults to <output-dir>/.parquet-shadow/inventory.sqlite.
-    #[arg(long)]
+    #[arg(long, env = "PENSIEVE_PARQUET_SHADOW_STATE_DB")]
     parquet_shadow_state_db: Option<PathBuf>,
 
     /// Durable local staging directory for the Parquet shadow.
     ///
     /// Defaults to <output-dir>/.parquet-shadow/staging.
-    #[arg(long)]
+    #[arg(long, env = "PENSIEVE_PARQUET_SHADOW_STAGING_DIR")]
     parquet_shadow_staging_dir: Option<PathBuf>,
 
     /// Immutable object-key prefix used by the Parquet shadow.
-    #[arg(long, default_value = "nostr/v1")]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_OBJECT_PREFIX",
+        default_value = "nostr/v1"
+    )]
     parquet_shadow_object_prefix: String,
 
     /// Target represented bytes per live Parquet object.
-    #[arg(long, default_value_t = pensieve_lake::DEFAULT_TARGET_UNCOMPRESSED_BYTES)]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_TARGET_UNCOMPRESSED_BYTES",
+        default_value_t = pensieve_lake::DEFAULT_TARGET_UNCOMPRESSED_BYTES
+    )]
     parquet_shadow_target_uncompressed_bytes: usize,
 
     /// Maximum accepted notepack frame size in the Parquet shadow.
-    #[arg(long, default_value_t = 16 * 1024 * 1024)]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_MAX_EVENT_BYTES",
+        default_value_t = 16 * 1024 * 1024
+    )]
     parquet_shadow_max_event_bytes: usize,
 
     /// Maximum age of an open live batch while the Parquet shadow is enabled.
     ///
     /// The timer force-seals the authoritative notepack segment; the resulting
     /// sealed file is then the durable Parquet work unit. Zero disables the timer.
-    #[arg(long, default_value = "300")]
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_MAX_BATCH_AGE_SECS",
+        default_value = "300"
+    )]
     parquet_shadow_max_batch_age_secs: u64,
+
+    /// Replay only sealed segment numbers at or above this inclusive floor.
+    ///
+    /// For a first production activation, stop the ingester and set this to one
+    /// greater than the highest pre-existing segment number. The policy is
+    /// persisted in the shadow inventory and cannot drift across restarts.
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_REPLAY_FROM_SEGMENT",
+        conflicts_with = "no_parquet_shadow_replay"
+    )]
+    parquet_shadow_replay_from_segment: Option<u64>,
+
+    /// Explicitly replay every already sealed notepack file when the shadow starts.
+    ///
+    /// This is intended for isolated/local use. Production first activation
+    /// should use --parquet-shadow-replay-from-segment instead.
+    #[arg(
+        long,
+        env = "PENSIEVE_PARQUET_SHADOW_REPLAY_ALL",
+        conflicts_with_all = ["parquet_shadow_replay_from_segment", "no_parquet_shadow_replay"]
+    )]
+    parquet_shadow_replay_all: bool,
 
     /// Do not replay already sealed notepack files when the shadow starts.
     ///
-    /// Replay is safe and idempotent through the inventory, and is enabled by
-    /// default so a process crash cannot lose an in-memory notification.
-    #[arg(long)]
+    /// This gives up restart recovery for a missed in-memory notification and
+    /// should only be used for controlled tests.
+    #[arg(long, env = "PENSIEVE_PARQUET_SHADOW_NO_REPLAY")]
     no_parquet_shadow_replay: bool,
 
     /// Initial seed relay URLs (comma-separated, overrides seed file)
@@ -1348,6 +1407,19 @@ fn parquet_shadow_config(args: &Args) -> Result<ParquetShadowConfig> {
         .parquet_shadow_staging_dir
         .clone()
         .unwrap_or_else(|| control_dir.join("staging"));
+    let replay_dir = match (
+        args.parquet_shadow_replay_from_segment,
+        args.parquet_shadow_replay_all,
+        args.no_parquet_shadow_replay,
+    ) {
+        (Some(_), false, false) | (None, true, false) => Some(args.output_dir.clone()),
+        (None, false, true) => None,
+        _ => anyhow::bail!(
+            "choose exactly one Parquet shadow replay policy: \
+             --parquet-shadow-replay-from-segment, --parquet-shadow-replay-all, \
+             or --no-parquet-shadow-replay"
+        ),
+    };
     let publisher = match (
         &args.parquet_shadow_lake_dir,
         &args.parquet_shadow_s3_bucket,
@@ -1371,7 +1443,8 @@ fn parquet_shadow_config(args: &Args) -> Result<ParquetShadowConfig> {
             max_event_bytes: args.parquet_shadow_max_event_bytes,
         },
         publisher,
-        replay_dir: (!args.no_parquet_shadow_replay).then(|| args.output_dir.clone()),
+        replay_dir,
+        replay_from_segment: args.parquet_shadow_replay_from_segment,
     })
 }
 
@@ -1396,6 +1469,7 @@ fn start_optional_parquet_shadow(
         state_db = %config.state_db.display(),
         staging_dir = %config.campaign.staging_dir.display(),
         replay_existing = config.replay_dir.is_some(),
+        replay_from_segment = ?config.replay_from_segment,
         "starting Parquet shadow worker"
     );
     let (sender, receiver) = crossbeam_channel::unbounded::<SealedSegment>();
@@ -1451,6 +1525,39 @@ mod tests {
     use super::*;
 
     #[test]
+    fn shadow_target_requires_an_explicit_replay_policy() {
+        let args = Args::try_parse_from([
+            "pensieve-ingest",
+            "--parquet-shadow-lake-dir",
+            "/tmp/parquet-shadow-test",
+        ])
+        .expect("arguments parse");
+
+        assert!(parquet_shadow_config(&args).is_err());
+    }
+
+    #[test]
+    fn shadow_replay_floor_configures_inclusive_restart_replay() {
+        let args = Args::try_parse_from([
+            "pensieve-ingest",
+            "--output-dir",
+            "/tmp/parquet-shadow-segments",
+            "--parquet-shadow-lake-dir",
+            "/tmp/parquet-shadow-test",
+            "--parquet-shadow-replay-from-segment",
+            "42",
+        ])
+        .expect("arguments parse");
+
+        let config = parquet_shadow_config(&args).expect("valid shadow config");
+        assert_eq!(
+            config.replay_dir,
+            Some(PathBuf::from("/tmp/parquet-shadow-segments"))
+        );
+        assert_eq!(config.replay_from_segment, Some(42));
+    }
+
+    #[test]
     fn shadow_initialization_failure_disables_only_the_optional_sink() {
         let directory = tempfile::tempdir().expect("temporary directory");
         let blocking_file = directory.path().join("not-a-directory");
@@ -1462,6 +1569,7 @@ mod tests {
                 root: blocking_file.join("lake"),
             },
             replay_dir: None,
+            replay_from_segment: None,
         };
 
         assert!(start_optional_parquet_shadow(Ok(config)).is_none());

--- a/crates/pensieve-ingest/src/pipeline/parquet_shadow.rs
+++ b/crates/pensieve-ingest/src/pipeline/parquet_shadow.rs
@@ -17,6 +17,8 @@ use pensieve_lake::{
 
 use super::SealedSegment;
 
+const REPLAY_POLICY_SETTING: &str = "parquet_shadow.replay_policy.v1";
+
 /// Publication target for the live shadow sink.
 #[derive(Clone, Debug)]
 pub enum ParquetShadowPublisher {
@@ -40,6 +42,12 @@ pub struct ParquetShadowConfig {
     pub publisher: ParquetShadowPublisher,
     /// Directory scanned for sealed work units before consuming live notifications.
     pub replay_dir: Option<PathBuf>,
+    /// Inclusive segment-number floor for startup replay.
+    ///
+    /// This lets a new live shadow take ownership of future segments without
+    /// replaying the pre-existing historical archive. The effective replay
+    /// policy is persisted in the inventory and cannot drift across restarts.
+    pub replay_from_segment: Option<u64>,
 }
 
 /// Start the shadow worker and wait until its inventory and publisher initialize.
@@ -91,8 +99,15 @@ struct ShadowWorker {
 
 impl ShadowWorker {
     fn new(config: ParquetShadowConfig) -> Result<Self> {
-        let inventory = Inventory::open(&config.state_db)
+        let mut inventory = Inventory::open(&config.state_db)
             .with_context(|| format!("failed to open {}", config.state_db.display()))?;
+        let replay_policy = replay_policy(&config);
+        let policy_is_recorded = inventory
+            .setting(REPLAY_POLICY_SETTING)
+            .context("failed to load durable Parquet shadow replay policy")?
+            .is_some();
+        validate_replay_floor(&config, policy_is_recorded)?;
+        ensure_inventory_settings(&mut inventory, &config, &replay_policy)?;
         let publisher: Box<dyn Publisher> = match &config.publisher {
             ParquetShadowPublisher::Local { root } => Box::new(
                 LocalObjectStore::new(root)
@@ -113,11 +128,12 @@ impl ShadowWorker {
     fn run(&mut self, receiver: Receiver<SealedSegment>) {
         gauge!("parquet_shadow_running").set(1.0);
         if let Some(replay_dir) = self.config.replay_dir.clone() {
-            match discover_sealed_segments(&replay_dir) {
+            match discover_sealed_segments(&replay_dir, self.config.replay_from_segment) {
                 Ok(paths) => {
                     tracing::info!(
                         path = %replay_dir.display(),
                         segments = paths.len(),
+                        replay_from_segment = ?self.config.replay_from_segment,
                         "replaying sealed segments through Parquet shadow"
                     );
                     for path in paths {
@@ -177,19 +193,141 @@ impl ShadowWorker {
     }
 }
 
-fn discover_sealed_segments(directory: &Path) -> std::io::Result<Vec<PathBuf>> {
+fn ensure_inventory_settings(
+    inventory: &mut Inventory,
+    config: &ParquetShadowConfig,
+    replay_policy: &str,
+) -> Result<()> {
+    let publisher = match &config.publisher {
+        ParquetShadowPublisher::Local { root } => {
+            format!("local:{}", root.to_string_lossy())
+        }
+        ParquetShadowPublisher::S3(s3) => format!(
+            "s3:bucket={};region={};endpoint={};force_path_style={}",
+            s3.bucket,
+            s3.region.as_deref().unwrap_or_default(),
+            s3.endpoint_url.as_deref().unwrap_or_default(),
+            s3.force_path_style
+        ),
+    };
+    let settings = [
+        (REPLAY_POLICY_SETTING, replay_policy.to_owned()),
+        ("parquet_shadow.publisher.v1", publisher),
+        (
+            "parquet_shadow.object_prefix.v1",
+            config.campaign.object_prefix.clone(),
+        ),
+        (
+            "parquet_shadow.target_uncompressed_bytes.v1",
+            config.campaign.target_uncompressed_bytes.to_string(),
+        ),
+        (
+            "parquet_shadow.max_event_bytes.v1",
+            config.campaign.max_event_bytes.to_string(),
+        ),
+        (
+            "parquet_shadow.staging_dir.v1",
+            config.campaign.staging_dir.to_string_lossy().into_owned(),
+        ),
+    ];
+    for (key, value) in settings {
+        inventory
+            .ensure_setting(key, &value)
+            .with_context(|| format!("Parquet shadow setting {key} differs from its inventory"))?;
+    }
+    Ok(())
+}
+
+fn replay_policy(config: &ParquetShadowConfig) -> String {
+    match (config.replay_dir.is_some(), config.replay_from_segment) {
+        (false, _) => "disabled".to_owned(),
+        (true, Some(segment)) => format!("from-segment:{segment}"),
+        (true, None) => "all".to_owned(),
+    }
+}
+
+fn validate_replay_floor(config: &ParquetShadowConfig, policy_is_recorded: bool) -> Result<()> {
+    let (Some(directory), Some(floor)) = (&config.replay_dir, config.replay_from_segment) else {
+        return Ok(());
+    };
+    let next_segment = next_segment_number(directory).with_context(|| {
+        format!(
+            "failed to inspect {} for the Parquet shadow replay floor",
+            directory.display()
+        )
+    })?;
+    if (!policy_is_recorded && floor != next_segment)
+        || (policy_is_recorded && next_segment < floor)
+    {
+        let requirement = if policy_is_recorded {
+            "at or below the next segment number"
+        } else {
+            "exactly the next segment number on first activation"
+        };
+        anyhow::bail!("Parquet shadow replay floor {floor} must be {requirement} {next_segment}");
+    }
+    Ok(())
+}
+
+fn next_segment_number(directory: &Path) -> std::io::Result<u64> {
+    let mut highest = None;
+    if directory.exists() {
+        for entry in fs::read_dir(directory)? {
+            let path = entry?.path();
+            if path.is_file()
+                && let Some(segment) = segment_number(&path)
+            {
+                highest = Some(highest.map_or(segment, |current: u64| current.max(segment)));
+            }
+        }
+    }
+    highest.map_or(Ok(0), |segment| {
+        segment.checked_add(1).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "segment number space exhausted",
+            )
+        })
+    })
+}
+
+fn discover_sealed_segments(
+    directory: &Path,
+    replay_from_segment: Option<u64>,
+) -> std::io::Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     if !directory.exists() {
         return Ok(paths);
     }
     for entry in fs::read_dir(directory)? {
         let path = entry?.path();
-        if path.is_file() && is_sealed_notepack(&path) && !has_compressed_replacement(&path) {
+        if path.is_file()
+            && is_sealed_notepack(&path)
+            && segment_is_at_or_after(&path, replay_from_segment)
+            && !has_compressed_replacement(&path)
+        {
             paths.push(path);
         }
     }
     paths.sort();
     Ok(paths)
+}
+
+fn segment_is_at_or_after(path: &Path, replay_from_segment: Option<u64>) -> bool {
+    let Some(floor) = replay_from_segment else {
+        return true;
+    };
+    segment_number(path).is_some_and(|segment| segment >= floor)
+}
+
+fn segment_number(path: &Path) -> Option<u64> {
+    let name = path.file_name()?.to_str()?;
+    let rest = name.strip_prefix("segment-")?;
+    let number = rest
+        .strip_suffix(".notepack.gz")
+        .or_else(|| rest.strip_suffix(".notepack"))
+        .or_else(|| rest.strip_suffix(".notepack.open"))?;
+    number.parse().ok()
 }
 
 fn has_compressed_replacement(path: &Path) -> bool {
@@ -226,7 +364,7 @@ mod tests {
             fs::write(directory.path().join(name), []).unwrap();
         }
 
-        let found = discover_sealed_segments(directory.path()).unwrap();
+        let found = discover_sealed_segments(directory.path(), None).unwrap();
         let names: Vec<_> = found
             .iter()
             .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
@@ -239,6 +377,115 @@ mod tests {
                 "segment-000000004.notepack.gz"
             ]
         );
+    }
+
+    #[test]
+    fn discovery_replay_floor_is_inclusive_and_ignores_historical_segments() {
+        let directory = tempfile::tempdir().unwrap();
+        for name in [
+            "segment-000000040.notepack.gz",
+            "segment-000000041.notepack",
+            "segment-000000042.notepack",
+            "segment-000000042.notepack.gz",
+            "segment-000000043.notepack.gz",
+            "other-000000100.notepack.gz",
+        ] {
+            fs::write(directory.path().join(name), []).unwrap();
+        }
+
+        let found = discover_sealed_segments(directory.path(), Some(42)).unwrap();
+        let names: Vec<_> = found
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "segment-000000042.notepack.gz",
+                "segment-000000043.notepack.gz"
+            ]
+        );
+    }
+
+    #[test]
+    fn first_replay_floor_must_match_next_segment_and_then_remains_durable() {
+        let directory = tempfile::tempdir().unwrap();
+        let segment_dir = directory.path().join("segments");
+        fs::create_dir(&segment_dir).unwrap();
+        fs::write(segment_dir.join("segment-000000041.notepack.gz"), []).unwrap();
+        let state_db = directory.path().join("inventory.sqlite");
+        let config = |floor| ParquetShadowConfig {
+            state_db: state_db.clone(),
+            campaign: CampaignConfig::new(directory.path().join("staging")),
+            publisher: ParquetShadowPublisher::Local {
+                root: directory.path().join("lake"),
+            },
+            replay_dir: Some(segment_dir.clone()),
+            replay_from_segment: Some(floor),
+        };
+
+        assert!(ShadowWorker::new(config(41)).is_err());
+        ShadowWorker::new(config(42)).expect("next segment is a safe first floor");
+
+        fs::write(segment_dir.join("segment-000000100.notepack.open"), []).unwrap();
+        ShadowWorker::new(config(42)).expect("recorded floor survives later segments");
+        assert!(ShadowWorker::new(config(43)).is_err());
+    }
+
+    #[test]
+    fn restart_replays_live_segment_without_replaying_historical_segment() {
+        let directory = tempfile::tempdir().unwrap();
+        let segment_dir = directory.path().join("segments");
+        let lake_dir = directory.path().join("lake");
+        let inventory_path = directory.path().join("inventory.sqlite");
+        fs::create_dir(&segment_dir).unwrap();
+        fs::write(segment_dir.join("segment-000000041.notepack.gz"), []).unwrap();
+        let config = ParquetShadowConfig {
+            state_db: inventory_path.clone(),
+            campaign: CampaignConfig::new(directory.path().join("staging")),
+            publisher: ParquetShadowPublisher::Local { root: lake_dir },
+            replay_dir: Some(segment_dir.clone()),
+            replay_from_segment: Some(42),
+        };
+
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        drop(sender);
+        start_parquet_shadow(config.clone(), receiver)
+            .unwrap()
+            .join()
+            .unwrap();
+
+        let segment_writer = SegmentWriter::new(
+            SegmentConfig {
+                output_dir: segment_dir,
+                compress: false,
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .unwrap();
+        let event = EventBuilder::new(Kind::TextNote, "restart replay")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        segment_writer
+            .write(pack_nostr_event(&event).unwrap())
+            .unwrap();
+        let sealed = segment_writer.seal().unwrap().expect("sealed segment");
+        assert_eq!(sealed.segment_number, 42);
+        drop(segment_writer);
+
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        drop(sender);
+        start_parquet_shadow(config, receiver)
+            .unwrap()
+            .join()
+            .unwrap();
+
+        let inventory = Inventory::open(inventory_path).unwrap();
+        let active = inventory.active_raw_objects().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].row_count, 1);
     }
 
     #[test]
@@ -269,6 +516,7 @@ mod tests {
                 },
                 publisher: ParquetShadowPublisher::Local { root: lake_dir },
                 replay_dir: None,
+                replay_from_segment: None,
             },
             receiver,
         )

--- a/crates/pensieve-lake/src/error.rs
+++ b/crates/pensieve-lake/src/error.rs
@@ -31,6 +31,17 @@ pub enum Error {
         reason: String,
     },
 
+    /// An immutable inventory setting differs from the value recorded on first use.
+    #[error("inventory setting {key} is already {actual}, refusing requested value {requested}")]
+    InventorySettingConflict {
+        /// Stable setting key.
+        key: String,
+        /// Requested setting value.
+        requested: String,
+        /// Value already recorded in the inventory.
+        actual: String,
+    },
+
     /// A state transition is not valid for the current work-unit state.
     #[error("invalid work-unit transition for {work_unit_id}: {from} -> {to}")]
     InvalidTransition {

--- a/crates/pensieve-lake/src/inventory.rs
+++ b/crates/pensieve-lake/src/inventory.rs
@@ -316,6 +316,12 @@ impl Inventory {
 
             CREATE INDEX IF NOT EXISTS objects_active_kind
                 ON objects(state, kind, object_key);
+
+            CREATE TABLE IF NOT EXISTS inventory_settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                created_at INTEGER NOT NULL DEFAULT (unixepoch())
+            );
             "#,
         )?;
         ensure_column(
@@ -343,6 +349,42 @@ impl Inventory {
             "ALTER TABLE objects ADD COLUMN writer_version TEXT NOT NULL DEFAULT 'unknown'",
         )?;
         Ok(Self { connection })
+    }
+
+    /// Record an immutable operational setting or verify its previously recorded value.
+    ///
+    /// Settings live in the external inventory, not canonical Parquet metadata.
+    /// This is intended for safety boundaries which must survive process restarts.
+    pub fn ensure_setting(&mut self, key: &str, value: &str) -> Result<()> {
+        self.connection.execute(
+            "INSERT OR IGNORE INTO inventory_settings (key, value) VALUES (?1, ?2)",
+            params![key, value],
+        )?;
+        let actual: String = self.connection.query_row(
+            "SELECT value FROM inventory_settings WHERE key = ?1",
+            [key],
+            |row| row.get(0),
+        )?;
+        if actual != value {
+            return Err(Error::InventorySettingConflict {
+                key: key.to_owned(),
+                requested: value.to_owned(),
+                actual,
+            });
+        }
+        Ok(())
+    }
+
+    /// Load one operational inventory setting.
+    pub fn setting(&self, key: &str) -> Result<Option<String>> {
+        self.connection
+            .query_row(
+                "SELECT value FROM inventory_settings WHERE key = ?1",
+                [key],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(Into::into)
     }
 
     /// Register a work unit or verify that an existing identity is compatible.

--- a/crates/pensieve-lake/tests/inventory_settings.rs
+++ b/crates/pensieve-lake/tests/inventory_settings.rs
@@ -1,0 +1,43 @@
+use pensieve_lake::{Error, Inventory};
+
+#[test]
+fn immutable_inventory_setting_survives_reopen_and_rejects_drift() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("inventory.sqlite");
+
+    let mut inventory = Inventory::open(&path).expect("open inventory");
+    inventory
+        .ensure_setting("parquet_shadow.replay_policy.v1", "from-segment:42")
+        .expect("record setting");
+    assert_eq!(
+        inventory
+            .setting("parquet_shadow.replay_policy.v1")
+            .expect("load setting")
+            .as_deref(),
+        Some("from-segment:42")
+    );
+    assert_eq!(
+        inventory.setting("missing").expect("load missing setting"),
+        None
+    );
+    drop(inventory);
+
+    let mut reopened = Inventory::open(path).expect("reopen inventory");
+    reopened
+        .ensure_setting("parquet_shadow.replay_policy.v1", "from-segment:42")
+        .expect("same setting is idempotent");
+    let error = reopened
+        .ensure_setting("parquet_shadow.replay_policy.v1", "all")
+        .expect_err("setting drift must fail");
+
+    assert!(matches!(
+        error,
+        Error::InventorySettingConflict {
+            key,
+            requested,
+            actual,
+        } if key == "parquet_shadow.replay_policy.v1"
+            && requested == "all"
+            && actual == "from-segment:42"
+    ));
+}

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -439,6 +439,12 @@ shared infrastructure. Compaction is not required to finish P2.
       Parquet includes events observed after live activation. Events accepted
       between activation and sealing `H` intentionally occur in both paths.
       Logical dedup handles that overlap. The boundary is never a timestamp.
+  - [x] The live shadow accepts an inclusive segment-number replay floor and
+        persists the resulting replay policy in its SQLite inventory. On first
+        production activation, the operator records `max(existing segment) + 1`
+        while ingestion is stopped. Restarts replay that segment and every later
+        sealed segment, but cannot silently widen the boundary to the historical
+        archive or change the policy.
 - [ ] Before P5, prove the chosen unsealed-buffer durability contract across the
       intended failure domain. Zero RPO requires synchronous/acknowledged
       durability outside the live process or host; asynchronous replication

--- a/ops/RUNBOOK.md
+++ b/ops/RUNBOOK.md
@@ -81,7 +81,8 @@ events may have old or future `created_at` values.
    printf 'highest=%s replay_from=%s\n' "$highest_segment" "$replay_from_segment"
    ```
 3. Install the restricted configuration, set
-   `PENSIEVE_PARQUET_SHADOW_REPLAY_FROM_SEGMENT` to that exact replay floor,
+   `PENSIEVE_PARQUET_SHADOW_REPLAY_FROM_SEGMENT` to that exact replay floor
+   (uncommenting the example entry),
    and verify the object prefix and writer-size settings match the historical
    campaign:
    ```bash

--- a/ops/RUNBOOK.md
+++ b/ops/RUNBOOK.md
@@ -51,6 +51,67 @@ provisioning). The ingester exposes Prometheus metrics on `:9091`.
 Verify: `systemctl status pensieve pensieve-api pensieve-ingest pensieve-preview`,
 `curl localhost:8080/health`, `journalctl -u pensieve-ingest -f`.
 
+## First live Parquet shadow activation
+
+Installing the binary and systemd unit does **not** enable the shadow. The
+optional `/etc/pensieve/parquet-shadow.env` file is the activation switch; seed
+it from [`ops/parquet-shadow.env.example`](parquet-shadow.env.example) without
+putting credentials in Git.
+
+The first activation must establish a segment-number boundary while ingestion
+is stopped. A timestamp is not a safe boundary because newly received Nostr
+events may have old or future `created_at` values.
+
+1. Stop the ingester gracefully and verify no compression is still in flight:
+   ```bash
+   sudo systemctl stop pensieve-ingest
+   find /archive/segments -maxdepth 1 -name '*.open' -print
+   ```
+2. Compute the inclusive replay floor as one greater than the highest existing
+   sealed or open segment:
+   ```bash
+   highest_segment="$(
+     find /archive/segments -maxdepth 1 -type f -printf '%f\n' |
+       sed -nE 's/^segment-([0-9]+)\.notepack(\.gz|\.open)?$/\1/p' |
+       sort -n |
+       tail -n 1
+   )"
+   test -n "$highest_segment"
+   replay_from_segment="$((10#$highest_segment + 1))"
+   printf 'highest=%s replay_from=%s\n' "$highest_segment" "$replay_from_segment"
+   ```
+3. Install the restricted configuration, set
+   `PENSIEVE_PARQUET_SHADOW_REPLAY_FROM_SEGMENT` to that exact replay floor,
+   and verify the object prefix and writer-size settings match the historical
+   campaign:
+   ```bash
+   sudo install -m 600 -o pensieve -g pensieve \
+     ops/parquet-shadow.env.example /etc/pensieve/parquet-shadow.env
+   sudo -u pensieve nano /etc/pensieve/parquet-shadow.env
+   ```
+4. Start the ingester and verify that the durable replay policy is the expected
+   `from-segment:N`, historical segment numbers are not queued, and the normal
+   API/ingest metrics remain healthy:
+   ```bash
+   sudo systemctl start pensieve-ingest
+   journalctl -u pensieve-ingest --since '2 minutes ago' --no-pager
+   sqlite3 /archive/segments/.parquet-shadow/inventory.sqlite \
+     "SELECT key, value FROM inventory_settings ORDER BY key;"
+   ```
+5. Let the five-minute maximum-age timer seal the first live segment. Record
+   that segment as high-water mark `H`, verify its work unit is `published`,
+   and verify the corresponding immutable object and checksum in object
+   storage. The historical campaign's catch-up pass must include every sealed
+   segment through `H`; the intentional overlap is removed logically by event
+   ID later.
+
+On every restart, the live inventory rejects a changed replay policy, object
+store, object prefix, writer-size limit, frame-size limit, or staging directory.
+The ingester continues with its authoritative notepack path while logging that
+the optional shadow is disabled. Treat that as a failed shadow deployment:
+correct the configuration deliberately; do not delete a populated inventory
+merely to bypass the guard.
+
 ## One-time cutover (ops/ move + secrets → /etc)
 
 The move of compose/systemd paths and secrets to `/etc` must happen in lockstep with

--- a/ops/parquet-shadow.env.example
+++ b/ops/parquet-shadow.env.example
@@ -1,0 +1,34 @@
+# Optional live Parquet shadow configuration for pensieve-ingest.
+#
+# Install as /etc/pensieve/parquet-shadow.env with mode 0600. The systemd unit
+# ignores a missing file, so installing code and the unit does not enable the
+# shadow. Never commit real object-storage credentials.
+
+AWS_ACCESS_KEY_ID=replace-me
+AWS_SECRET_ACCESS_KEY=replace-me
+AWS_REGION=hel1
+
+PENSIEVE_PARQUET_SHADOW_S3_BUCKET=replace-me
+PENSIEVE_PARQUET_SHADOW_S3_REGION=hel1
+PENSIEVE_PARQUET_SHADOW_S3_ENDPOINT_URL=https://hel1.your-objectstorage.com
+PENSIEVE_PARQUET_SHADOW_S3_FORCE_PATH_STYLE=false
+
+# Must match the historical campaign so overlapping work units produce the
+# same immutable object keys and bytes.
+PENSIEVE_PARQUET_SHADOW_OBJECT_PREFIX=nostr/v1
+PENSIEVE_PARQUET_SHADOW_TARGET_UNCOMPRESSED_BYTES=536870912
+PENSIEVE_PARQUET_SHADOW_MAX_EVENT_BYTES=16777216
+
+# Five minutes keeps live objects reasonably current without making event time
+# part of the file boundary.
+PENSIEVE_PARQUET_SHADOW_MAX_BATCH_AGE_SECS=300
+
+# REQUIRED for the first production activation. While the ingester is stopped,
+# set this to one greater than the highest pre-existing segment number. The
+# value becomes an immutable setting in the live shadow inventory.
+PENSIEVE_PARQUET_SHADOW_REPLAY_FROM_SEGMENT=replace-with-next-segment-number
+
+# Defaults are under /archive/segments/.parquet-shadow. They are shown
+# explicitly here so operators can back up and monitor the live inventory.
+PENSIEVE_PARQUET_SHADOW_STATE_DB=/archive/segments/.parquet-shadow/inventory.sqlite
+PENSIEVE_PARQUET_SHADOW_STAGING_DIR=/archive/segments/.parquet-shadow/staging

--- a/ops/parquet-shadow.env.example
+++ b/ops/parquet-shadow.env.example
@@ -24,9 +24,9 @@ PENSIEVE_PARQUET_SHADOW_MAX_EVENT_BYTES=16777216
 PENSIEVE_PARQUET_SHADOW_MAX_BATCH_AGE_SECS=300
 
 # REQUIRED for the first production activation. While the ingester is stopped,
-# set this to one greater than the highest pre-existing segment number. The
-# value becomes an immutable setting in the live shadow inventory.
-PENSIEVE_PARQUET_SHADOW_REPLAY_FROM_SEGMENT=replace-with-next-segment-number
+# uncomment this and set it to one greater than the highest pre-existing segment
+# number. The value becomes an immutable setting in the live shadow inventory.
+# PENSIEVE_PARQUET_SHADOW_REPLAY_FROM_SEGMENT=
 
 # Defaults are under /archive/segments/.parquet-shadow. They are shown
 # explicitly here so operators can back up and monitor the live inventory.

--- a/ops/systemd/pensieve-ingest.service
+++ b/ops/systemd/pensieve-ingest.service
@@ -9,6 +9,7 @@ Type=simple
 User=pensieve
 Group=pensieve
 WorkingDirectory=/home/pensieve/pensieve
+EnvironmentFile=-/etc/pensieve/parquet-shadow.env
 
 # Binary location (after cargo build --release)
 # Tor proxy enabled by default - .onion relays route through Tor, clearnet connects directly
@@ -61,4 +62,3 @@ ReadWritePaths=/data /archive
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
## Summary

- require an explicit Parquet shadow replay policy instead of implicitly replaying every sealed segment
- add an inclusive `--parquet-shadow-replay-from-segment` boundary and verify that first activation starts at exactly the next segment number
- persist the replay policy, publisher identity, object prefix, writer limits, and staging path as immutable SQLite inventory settings
- expose shadow configuration through an optional restricted systemd environment file
- document the production activation, high-water mark, rollback, and historical catch-up procedure

## Why

The historical archive conversion is already running separately. Enabling the existing live shadow against an empty inventory would scan roughly 7,700 pre-existing notepack segments and duplicate that campaign. A missed or changed bootstrap boundary could also create a restart gap.

This change makes the historical/live boundary explicit and durable. Installing the code and systemd unit alone remains inert because `/etc/pensieve/parquet-shadow.env` is optional; the normal notepack and ClickHouse paths continue unchanged until an operator deliberately activates the shadow.

## Operational impact

The intended rollout remains two-stage:

1. deploy and restart the ordinary ingester with no shadow environment file;
2. after that soak is healthy, stop ingestion, calculate `max(existing segment) + 1`, install the restricted shadow configuration, and validate the first published live segment before leaving the shadow enabled.

A shadow startup or publication failure cannot fail the authoritative notepack path.

## Validation

- `just precommit`
- focused restart test proves a live segment is replayed after restart while an older historical segment is excluded
- inventory tests prove immutable settings survive reopen and reject configuration drift
- CLI tests prove a publication target requires an explicit replay policy