### PR TITLE
Accept frame-bounded notepack events above 256 KiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,6 +3095,7 @@ dependencies = [
  "parking_lot",
  "pensieve-core",
  "pensieve-lake",
+ "pensieve-parquet",
  "prost",
  "rocksdb",
  "rusqlite",

--- a/crates/pensieve-ingest/Cargo.toml
+++ b/crates/pensieve-ingest/Cargo.toml
@@ -36,6 +36,7 @@ path = "src/bin/relay-cleanup.rs"
 # Internal crates
 pensieve-core = { path = "../pensieve-core" }
 pensieve-lake = { path = "../pensieve-lake" }
+pensieve-parquet = { path = "../pensieve-parquet" }
 
 # Nostr
 notepack.workspace = true

--- a/crates/pensieve-ingest/src/pipeline/clickhouse.rs
+++ b/crates/pensieve-ingest/src/pipeline/clickhouse.rs
@@ -23,7 +23,7 @@ use clickhouse::{Client, Row};
 use crossbeam_channel::Receiver;
 use flate2::read::GzDecoder;
 use metrics::counter;
-use notepack::NoteParser;
+use pensieve_parquet::CanonicalEvent;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{BufReader, Read};
@@ -395,40 +395,17 @@ impl ClickHouseIndexer {
 
     /// Parse notepack bytes into an EventRow.
     fn parse_notepack(data: &[u8]) -> Result<EventRow> {
-        use notepack::StringType;
-
-        let parser = NoteParser::new(data);
-        let note = parser
-            .into_note()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
-
-        // Convert tags to Vec<Vec<String>>
-        let mut tags: Vec<Vec<String>> = Vec::new();
-        let mut tags_iter = note.tags;
-        while let Some(tag_result) = tags_iter
-            .next_tag()
-            .map_err(|e| Error::Serialization(e.to_string()))?
-        {
-            let mut tag_vec: Vec<String> = Vec::new();
-            for elem in tag_result {
-                let elem = elem.map_err(|e| Error::Serialization(e.to_string()))?;
-                let s = match elem {
-                    StringType::Str(s) => s.to_string(),
-                    StringType::Bytes(b) => hex::encode(b),
-                };
-                tag_vec.push(s);
-            }
-            tags.push(tag_vec);
-        }
+        let event =
+            CanonicalEvent::from_notepack(data).map_err(|e| Error::Serialization(e.to_string()))?;
 
         Ok(EventRow {
-            id: hex::encode(note.id),
-            pubkey: hex::encode(note.pubkey),
-            created_at: note.created_at as u32,
-            kind: note.kind as u16,
-            content: note.content.to_string(),
-            sig: hex::encode(note.sig),
-            tags,
+            id: hex::encode(event.id()),
+            pubkey: hex::encode(event.pubkey()),
+            created_at: event.created_at() as u32,
+            kind: event.kind(),
+            content: event.content().to_owned(),
+            sig: hex::encode(event.signature()),
+            tags: event.tags().to_owned(),
             relay_source: String::new(), // Backfill doesn't have relay source
         })
     }
@@ -480,12 +457,44 @@ pub struct IndexerStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nostr_sdk::{EventBuilder, Keys, Kind, Timestamp};
+    use notepack::NoteBinary;
 
     #[test]
     fn test_config_default() {
         let config = ClickHouseConfig::default();
         assert_eq!(config.database, "nostr");
         assert_eq!(config.table, "events_local");
+    }
+
+    #[test]
+    fn clickhouse_parser_accepts_frame_bounded_large_content() {
+        let keys = Keys::parse("0000000000000000000000000000000000000000000000000000000000000001")
+            .expect("valid test secret key");
+        let event = EventBuilder::new(Kind::TextNote, "x".repeat(700_000))
+            .custom_created_at(Timestamp::from(1_700_000_000))
+            .sign_with_keys(&keys)
+            .expect("large event should sign");
+        let tags: Vec<Vec<String>> = event
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().iter().map(ToString::to_string).collect())
+            .collect();
+        let payload = NoteBinary {
+            id: event.id.as_bytes(),
+            pubkey: event.pubkey.as_bytes(),
+            sig: event.sig.as_ref(),
+            content: &event.content,
+            created_at: event.created_at.as_secs(),
+            kind: u64::from(event.kind.as_u16()),
+            tags: &tags,
+        }
+        .pack();
+
+        let row = ClickHouseIndexer::parse_notepack(&payload)
+            .expect("frame-bounded content should decode");
+        assert_eq!(row.id, event.id.to_hex());
+        assert_eq!(row.content.len(), 700_000);
     }
 
     // Integration tests would require a running ClickHouse instance

--- a/crates/pensieve-parquet/src/row.rs
+++ b/crates/pensieve-parquet/src/row.rs
@@ -1,7 +1,7 @@
 //! Raw inputs and validated, owned rows used by the canonical writer.
 
 use nostr::prelude::{Event, EventId, Kind, PublicKey, Signature, Tag, Tags, Timestamp};
-use notepack::{NoteParser, StringType};
+use notepack::{Error as NotepackError, SUPPORTED_VERSION};
 
 use crate::{Error, Result};
 
@@ -99,33 +99,12 @@ impl CanonicalEvent {
     }
 
     /// Decode and validate one strict notepack payload without converting it to JSON.
+    ///
+    /// The framed-segment readers bound the payload before calling this method.
+    /// Decoding therefore trusts the complete frame size as its allocation
+    /// boundary instead of notepack's unrelated 256 KiB convenience limit.
     pub fn from_notepack(payload: &[u8]) -> Result<Self> {
-        let note = NoteParser::new(payload).into_note_strict()?;
-        let kind =
-            u16::try_from(note.kind).map_err(|_| Error::KindOutOfRange { kind: note.kind })?;
-        let mut tags_cursor = note.tags.clone();
-        let mut tags = Vec::with_capacity(tags_cursor.len().try_into().unwrap_or(usize::MAX));
-
-        while let Some(mut elements) = tags_cursor.next_tag()? {
-            let mut tag = Vec::with_capacity(elements.remaining().try_into().unwrap_or(usize::MAX));
-            for element in &mut elements {
-                tag.push(match element? {
-                    StringType::Str(value) => value.to_owned(),
-                    StringType::Bytes(value) => hex::encode(value),
-                });
-            }
-            tags.push(tag);
-        }
-
-        Self::from_raw(RawEvent {
-            id: *note.id,
-            pubkey: *note.pubkey,
-            created_at: note.created_at,
-            kind,
-            tags,
-            content: note.content.to_owned(),
-            sig: *note.sig,
-        })
+        Self::from_raw(decode_notepack_strict(payload)?)
     }
 
     /// Validate and copy a typed Nostr event into a canonical archive row.
@@ -222,6 +201,121 @@ impl CanonicalEvent {
             .sum::<usize>();
         FIXED_FIELDS + OUTER_LIST_OFFSET + STRING_OFFSET + self.content.len() + tag_bytes
     }
+}
+
+/// Decode the complete notepack V1 payload using the enclosing frame as the
+/// allocation boundary.
+///
+/// `notepack::NoteParser::into_note_strict` imposes a fixed 256 KiB content
+/// limit even when the caller has already bounded the payload. Pensieve accepts
+/// frames up to 16 MiB, so parsing the small stable wire shape locally keeps
+/// strict trailing-byte validation without rejecting otherwise valid events.
+fn decode_notepack_strict(payload: &[u8]) -> Result<RawEvent> {
+    let mut input = payload;
+    let version = read_varint(&mut input)?;
+    if version != u64::from(SUPPORTED_VERSION) {
+        return Err(NotepackError::UnsupportedVersion(version).into());
+    }
+
+    let id = read_array(&mut input)?;
+    let pubkey = read_array(&mut input)?;
+    let sig = read_array(&mut input)?;
+    let created_at = read_varint(&mut input)?;
+    let kind_value = read_varint(&mut input)?;
+    let kind = u16::try_from(kind_value).map_err(|_| Error::KindOutOfRange { kind: kind_value })?;
+
+    let content_length = read_varint(&mut input)?;
+    let content_bytes = read_bytes(content_length, &mut input)?;
+    let content = std::str::from_utf8(content_bytes)
+        .map_err(NotepackError::from)?
+        .to_owned();
+
+    let tag_count = read_varint(&mut input)?;
+    ensure_count_can_fit(tag_count, input.len())?;
+    let mut tags = Vec::with_capacity(initial_capacity(tag_count));
+    for _ in 0..tag_count {
+        let element_count = read_varint(&mut input)?;
+        ensure_count_can_fit(element_count, input.len())?;
+        let mut tag = Vec::with_capacity(initial_capacity(element_count));
+        for _ in 0..element_count {
+            let tagged_length = read_varint(&mut input)?;
+            let is_bytes = tagged_length & 1 != 0;
+            let element = read_bytes(tagged_length >> 1, &mut input)?;
+            tag.push(if is_bytes {
+                hex::encode(element)
+            } else {
+                std::str::from_utf8(element)
+                    .map_err(NotepackError::from)?
+                    .to_owned()
+            });
+        }
+        tags.push(tag);
+    }
+
+    if !input.is_empty() {
+        return Err(NotepackError::TrailingBytes.into());
+    }
+
+    Ok(RawEvent {
+        id,
+        pubkey,
+        created_at,
+        kind,
+        tags,
+        content,
+        sig,
+    })
+}
+
+fn initial_capacity(count: u64) -> usize {
+    usize::try_from(count.min(4_096)).expect("bounded capacity fits usize")
+}
+
+fn ensure_count_can_fit(count: u64, remaining_bytes: usize) -> Result<()> {
+    if count > remaining_bytes as u64 {
+        return Err(NotepackError::Truncated.into());
+    }
+    Ok(())
+}
+
+fn read_array<const N: usize>(input: &mut &[u8]) -> Result<[u8; N]> {
+    let bytes = read_bytes(N as u64, input)?;
+    Ok(bytes.try_into().expect("read_bytes returned exact length"))
+}
+
+fn read_bytes<'a>(length: u64, input: &mut &'a [u8]) -> Result<&'a [u8]> {
+    let length = usize::try_from(length).map_err(|_| NotepackError::VarintOverflow)?;
+    if length > input.len() {
+        return Err(NotepackError::Truncated.into());
+    }
+    let (value, remaining) = input.split_at(length);
+    *input = remaining;
+    Ok(value)
+}
+
+fn read_varint(input: &mut &[u8]) -> Result<u64> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+
+    for (index, byte) in input.iter().copied().enumerate() {
+        let chunk = u64::from(byte & 0x7f);
+        if shift == 63 && chunk & 0x7e != 0 {
+            return Err(NotepackError::VarintOverflow.into());
+        }
+        value |= chunk << shift;
+
+        if byte & 0x80 == 0 {
+            *input = &input[index + 1..];
+            return Ok(value);
+        }
+
+        shift += 7;
+        if shift >= 64 {
+            return Err(NotepackError::VarintOverflow.into());
+        }
+    }
+
+    Err(NotepackError::VarintUnterminated.into())
 }
 
 impl TryFrom<&Event> for CanonicalEvent {

--- a/crates/pensieve-parquet/tests/validation.rs
+++ b/crates/pensieve-parquet/tests/validation.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use nostr::{Event, EventBuilder, Keys, Kind, Tag, Timestamp};
 use notepack::NoteBinary;
-use pensieve_parquet::{CanonicalEvent, RawEvent, validate_file, write_events};
+use pensieve_parquet::{CanonicalEvent, Error, RawEvent, validate_file, write_events};
 
 fn test_keys() -> Keys {
     Keys::parse("0000000000000000000000000000000000000000000000000000000000000001")
@@ -68,6 +68,52 @@ fn validates_raw_and_notepack_without_json() {
     assert_eq!(decoded.tags(), raw.tags);
     assert_eq!(decoded.content(), "");
     assert_eq!(decoded.created_at(), i64::MAX as u64 + 1);
+}
+
+#[test]
+fn strict_notepack_decoder_accepts_content_larger_than_256_kib() {
+    let event = EventBuilder::new(Kind::TextNote, "x".repeat(700_000))
+        .custom_created_at(Timestamp::from(1_700_000_000))
+        .sign_with_keys(&test_keys())
+        .expect("large event should sign");
+    let raw = raw_event(&event);
+    let payload = NoteBinary {
+        id: &raw.id,
+        pubkey: &raw.pubkey,
+        sig: &raw.sig,
+        content: &raw.content,
+        created_at: raw.created_at,
+        kind: u64::from(raw.kind),
+        tags: &raw.tags,
+    }
+    .pack();
+
+    let decoded =
+        CanonicalEvent::from_notepack(&payload).expect("frame-bounded content should decode");
+    assert_eq!(decoded.id(), &raw.id);
+    assert_eq!(decoded.content().len(), 700_000);
+}
+
+#[test]
+fn strict_notepack_decoder_still_rejects_trailing_bytes() {
+    let event = signed_event();
+    let raw = raw_event(&event);
+    let mut payload = NoteBinary {
+        id: &raw.id,
+        pubkey: &raw.pubkey,
+        sig: &raw.sig,
+        content: &raw.content,
+        created_at: raw.created_at,
+        kind: u64::from(raw.kind),
+        tags: &raw.tags,
+    }
+    .pack();
+    payload.push(0);
+
+    assert!(matches!(
+        CanonicalEvent::from_notepack(&payload),
+        Err(Error::Notepack(notepack::Error::TrailingBytes))
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- replace the Parquet path's fixed-256-KiB notepack decode with a strict V1 decoder bounded by the enclosing 16 MiB frame
- preserve unsupported-version, malformed-varint, truncation, UTF-8, and trailing-byte rejection
- route the ClickHouse segment indexer through the same canonical decoder
- add regression coverage using a signed 700 KB event

## Why

The first production Parquet shadow replay found one valid archived event whose 695,492-byte content exceeded `notepack::NoteParser::into_note_strict()`'s unrelated 256 KiB allocation ceiling. The authoritative segment frame was already bounded to 16 MiB, but both Parquet conversion and ClickHouse indexing rejected that event.

## Impact

Valid large Nostr events within the configured frame limit are now retained by both derived consumers. The outer 16 MiB frame guard remains in force, and strict complete-payload validation is preserved.

## Validation

- `just precommit`
- signed synthetic 700 KB event decodes in Parquet and ClickHouse paths
- trailing-byte regression remains rejected
- exact quarantined production frame from segment 7704 converted to one canonical row with zero rejects
- standalone canonical V1 validator passed the resulting Parquet file