### PR TITLE
Add unified active-file lake catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,6 +3122,8 @@ dependencies = [
  "notepack",
  "pensieve-parquet",
  "rusqlite",
+ "serde",
+ "serde_json",
  "sha2",
  "tempfile",
  "thiserror 2.0.17",

--- a/crates/pensieve-ingest/src/bin/jsonl.rs
+++ b/crates/pensieve-ingest/src/bin/jsonl.rs
@@ -751,6 +751,8 @@ fn finalize_pipeline(
         }
     }
 
+    segment_writer.wait_for_compression()?;
+
     // Update stats from segment writer
     let seg_stats = segment_writer.stats();
     stats.segments_sealed = seg_stats.segment_number as usize;

--- a/crates/pensieve-ingest/src/bin/proto.rs
+++ b/crates/pensieve-ingest/src/bin/proto.rs
@@ -767,6 +767,8 @@ fn finalize_pipeline(
         }
     }
 
+    segment_writer.wait_for_compression()?;
+
     // Get final stats from segment writer
     let seg_stats = segment_writer.stats();
     stats.notepack_bytes = seg_stats.total_bytes;

--- a/crates/pensieve-ingest/src/main.rs
+++ b/crates/pensieve-ingest/src/main.rs
@@ -1223,6 +1223,7 @@ async fn main() -> Result<()> {
             "sealed final segment"
         );
     }
+    segment_writer.wait_for_compression()?;
 
     // Flush dedupe
     dedupe.flush()?;

--- a/crates/pensieve-ingest/src/pipeline/segment.rs
+++ b/crates/pensieve-ingest/src/pipeline/segment.rs
@@ -34,6 +34,7 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::thread::JoinHandle;
 
 use super::dedupe::DedupeIndex;
 
@@ -168,6 +169,8 @@ pub struct SegmentWriter {
     total_bytes: AtomicUsize,
     /// Wrapped in Arc for sharing with background compression threads.
     total_compressed_bytes: Arc<AtomicUsize>,
+    /// Compression jobs must be joined before a finite writer process exits.
+    compression_threads: Mutex<Vec<JoinHandle<()>>>,
     sealed_senders: Vec<Sender<SealedSegment>>,
     /// Optional dedupe index. When present, every sealed segment's events are
     /// marked durably `Archived` here (after the segment file is fsync'd), which is
@@ -219,6 +222,7 @@ impl SegmentWriter {
             total_events: AtomicUsize::new(0),
             total_bytes: AtomicUsize::new(0),
             total_compressed_bytes: Arc::new(AtomicUsize::new(0)),
+            compression_threads: Mutex::new(Vec::new()),
             sealed_senders,
             dedupe,
         })
@@ -441,13 +445,15 @@ impl SegmentWriter {
         };
 
         if self.config.compress {
+            self.reap_finished_compression_threads();
+
             // Spawn background thread for compression to avoid blocking async runtime
             let gz_path = path.with_extension("notepack.gz");
             let senders = self.sealed_senders.clone();
             let total_compressed_bytes = self.total_compressed_bytes.clone();
             let sealed_for_notify = sealed.clone();
 
-            std::thread::spawn(move || {
+            let compression_thread = std::thread::spawn(move || {
                 match Self::compress_file_static(&path, &gz_path) {
                     Ok(compressed_bytes) => {
                         // Guard against divide-by-zero on an empty/forced seal.
@@ -503,6 +509,7 @@ impl SegmentWriter {
                     }
                 }
             });
+            self.compression_threads.lock().push(compression_thread);
         } else {
             tracing::info!(
                 "Sealed segment {}: {} events, {} bytes at {}",
@@ -521,6 +528,52 @@ impl SegmentWriter {
         }
 
         Ok(Some(sealed))
+    }
+
+    fn reap_finished_compression_threads(&self) {
+        let finished = {
+            let mut threads = self.compression_threads.lock();
+            let mut finished = Vec::new();
+            let mut index = 0;
+            while index < threads.len() {
+                if threads[index].is_finished() {
+                    finished.push(threads.swap_remove(index));
+                } else {
+                    index += 1;
+                }
+            }
+            finished
+        };
+
+        for handle in finished {
+            if handle.join().is_err() {
+                tracing::warn!("segment compression thread panicked");
+            }
+        }
+    }
+
+    /// Wait for all compression jobs started by this writer.
+    ///
+    /// Call this after the final [`Self::seal`] and before reading final
+    /// compression statistics or waiting for downstream consumers. The caller
+    /// must ensure no concurrent writes or seals can start new jobs.
+    pub fn wait_for_compression(&self) -> Result<()> {
+        let handles = std::mem::take(&mut *self.compression_threads.lock());
+        let mut panicked = false;
+
+        for handle in handles {
+            if handle.join().is_err() {
+                panicked = true;
+            }
+        }
+
+        if panicked {
+            return Err(Error::Segment(
+                "one or more segment compression threads panicked".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 
     fn notify_all(senders: &[Sender<SealedSegment>], sealed: &SealedSegment) {
@@ -631,6 +684,12 @@ impl Drop for SegmentWriter {
         // Seal any remaining segment on drop
         if let Err(e) = self.seal() {
             tracing::warn!(error = %compact_error(&e), "error sealing segment on drop");
+        }
+        if let Err(e) = self.wait_for_compression() {
+            tracing::warn!(
+                error = %compact_error(&e),
+                "error waiting for segment compression on drop"
+            );
         }
     }
 }
@@ -772,18 +831,10 @@ mod tests {
         let writer = SegmentWriter::new(config, None, None).unwrap();
         writer.write(test_event(1)).unwrap();
         writer.seal().unwrap();
+        writer.wait_for_compression().unwrap();
 
-        // Compression happens in a background thread, wait for it
         let segment_path = tmp.path().join("segment-000000000.notepack.gz");
         let uncompressed_path = tmp.path().join("segment-000000000.notepack");
-
-        // Wait up to 5 seconds for compression to complete
-        for _ in 0..50 {
-            if segment_path.exists() && !uncompressed_path.exists() {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
 
         // Check compressed file exists (9-digit format)
         assert!(segment_path.exists(), "Compressed file should exist");
@@ -793,6 +844,33 @@ mod tests {
             !uncompressed_path.exists(),
             "Uncompressed file should be deleted"
         );
+        assert!(writer.stats().total_compressed_bytes > 0);
+    }
+
+    #[test]
+    fn drop_waits_for_background_compression() {
+        let tmp = TempDir::new().unwrap();
+        {
+            let writer = SegmentWriter::new(
+                SegmentConfig {
+                    output_dir: tmp.path().to_path_buf(),
+                    compress: true,
+                    ..Default::default()
+                },
+                None,
+                None,
+            )
+            .unwrap();
+            writer.write(test_event(1)).unwrap();
+        }
+
+        assert!(tmp.path().join("segment-000000000.notepack.gz").exists());
+        assert!(
+            !tmp.path()
+                .join("segment-000000000.notepack.gz.open")
+                .exists()
+        );
+        assert!(!tmp.path().join("segment-000000000.notepack").exists());
     }
 
     #[test]

--- a/crates/pensieve-lake/Cargo.toml
+++ b/crates/pensieve-lake/Cargo.toml
@@ -20,6 +20,8 @@ clap = { version = "4.4", features = ["derive"] }
 hex.workspace = true
 pensieve-parquet = { path = "../pensieve-parquet" }
 rusqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 sha2.workspace = true
 tempfile = "3"
 thiserror.workspace = true

--- a/crates/pensieve-lake/src/bin/pensieve-lake-catalog.rs
+++ b/crates/pensieve-lake/src/bin/pensieve-lake-catalog.rs
@@ -1,0 +1,193 @@
+//! Export, merge, and verify deterministic active-file lake catalogs.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use pensieve_lake::{
+    ActiveRawFragment, Inventory, LocalObjectStore, Publisher, S3Publisher, S3PublisherConfig,
+    merge_active_raw_fragments, read_catalog_fragment, read_catalog_snapshot, sha256_file,
+    write_catalog_atomically,
+};
+
+#[derive(Debug, Parser)]
+#[command(about = "Build deterministic active-file snapshots from lake inventories")]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Export one writer's published work and active raw objects.
+    Export {
+        /// Existing SQLite inventory to read without modifying.
+        #[arg(long)]
+        inventory: PathBuf,
+        /// Stable, unique identity for this writer inventory.
+        #[arg(long)]
+        inventory_id: String,
+        /// Stable, non-secret identity shared by inventories using one object store.
+        #[arg(long)]
+        store_id: String,
+        /// Fragment JSON destination.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Merge one or more portable fragments into a unified snapshot.
+    Merge {
+        /// Fragment JSON inputs.
+        #[arg(long, required = true)]
+        fragment: Vec<PathBuf>,
+        /// Unified snapshot JSON destination.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Publish a validated snapshot at its immutable content-addressed key.
+    Publish {
+        /// Snapshot JSON to validate and publish.
+        #[arg(long)]
+        snapshot: PathBuf,
+        /// Local immutable object-store root. Conflicts with --s3-bucket.
+        #[arg(
+            long,
+            required_unless_present = "s3_bucket",
+            conflicts_with = "s3_bucket"
+        )]
+        lake_dir: Option<PathBuf>,
+        /// S3-compatible immutable object-store bucket. Conflicts with --lake-dir.
+        #[arg(
+            long,
+            required_unless_present = "lake_dir",
+            conflicts_with = "lake_dir"
+        )]
+        s3_bucket: Option<String>,
+        /// Optional AWS region override for S3 publication.
+        #[arg(long, requires = "s3_bucket")]
+        s3_region: Option<String>,
+        /// Optional endpoint for an S3-compatible provider.
+        #[arg(long, requires = "s3_bucket")]
+        s3_endpoint_url: Option<String>,
+        /// Use path-style S3 bucket addressing.
+        #[arg(long, requires = "s3_bucket")]
+        s3_force_path_style: bool,
+        /// Object-key prefix.
+        #[arg(long, default_value = "nostr/v1")]
+        object_prefix: String,
+    },
+    /// Verify a fragment or snapshot without changing it.
+    Verify {
+        /// Catalog JSON to verify.
+        #[arg(long, conflicts_with = "snapshot")]
+        fragment: Option<PathBuf>,
+        /// Snapshot JSON to verify.
+        #[arg(long, conflicts_with = "fragment")]
+        snapshot: Option<PathBuf>,
+    },
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("lake catalog failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    match Args::parse().command {
+        Command::Export {
+            inventory,
+            inventory_id,
+            store_id,
+            output,
+        } => {
+            let mut inventory = Inventory::open_read_only(inventory)?;
+            let fragment = ActiveRawFragment::export(&mut inventory, inventory_id, store_id)?;
+            write_catalog_atomically(output, &fragment)?;
+            println!(
+                "fragment={} inventory={} work_units={} objects={} rows={} bytes={}",
+                fragment.fragment_id,
+                fragment.inventory_id(),
+                fragment.totals().work_units,
+                fragment.totals().objects,
+                fragment.totals().physical_rows,
+                fragment.totals().object_bytes
+            );
+        }
+        Command::Merge { fragment, output } => {
+            let fragments = fragment
+                .into_iter()
+                .map(read_catalog_fragment)
+                .collect::<pensieve_lake::Result<Vec<_>>>()?;
+            let snapshot = merge_active_raw_fragments(fragments)?;
+            write_catalog_atomically(output, &snapshot)?;
+            println!(
+                "snapshot={} store={} work_units={} objects={} rows={} bytes={}",
+                snapshot.snapshot_id,
+                snapshot.store_id(),
+                snapshot.totals().work_units,
+                snapshot.totals().objects,
+                snapshot.totals().physical_rows,
+                snapshot.totals().object_bytes
+            );
+        }
+        Command::Publish {
+            snapshot,
+            lake_dir,
+            s3_bucket,
+            s3_region,
+            s3_endpoint_url,
+            s3_force_path_style,
+            object_prefix,
+        } => {
+            let catalog = read_catalog_snapshot(&snapshot)?;
+            let publisher: Box<dyn Publisher> = if let Some(root) = lake_dir {
+                Box::new(LocalObjectStore::new(root)?)
+            } else {
+                Box::new(S3Publisher::from_environment(S3PublisherConfig {
+                    bucket: s3_bucket.expect("clap requires one publication target"),
+                    region: s3_region,
+                    endpoint_url: s3_endpoint_url,
+                    force_path_style: s3_force_path_style,
+                })?)
+            };
+            let digest = catalog
+                .snapshot_id
+                .strip_prefix("sha256:")
+                .expect("validated snapshot IDs have a sha256 prefix");
+            let object_prefix = object_prefix.trim_matches('/');
+            if object_prefix.is_empty() {
+                return Err("--object-prefix must not be empty".into());
+            }
+            let key = format!("{object_prefix}/catalog/active-raw/{digest}.json");
+            let byte_size = std::fs::metadata(&snapshot)?.len();
+            let sha256 = sha256_file(&snapshot)?;
+            let published = publisher.publish(&key, &snapshot, byte_size, &sha256)?;
+            println!(
+                "published snapshot={} key={} bytes={} file_sha256={}",
+                catalog.snapshot_id, published.key, published.byte_size, published.sha256
+            );
+        }
+        Command::Verify { fragment, snapshot } => match (fragment, snapshot) {
+            (Some(path), None) => {
+                let fragment = read_catalog_fragment(path)?;
+                println!(
+                    "valid fragment={} inventory={} objects={}",
+                    fragment.fragment_id,
+                    fragment.inventory_id(),
+                    fragment.totals().objects
+                );
+            }
+            (None, Some(path)) => {
+                let snapshot = read_catalog_snapshot(path)?;
+                println!(
+                    "valid snapshot={} store={} objects={}",
+                    snapshot.snapshot_id,
+                    snapshot.store_id(),
+                    snapshot.totals().objects
+                );
+            }
+            _ => return Err("exactly one of --fragment or --snapshot is required".into()),
+        },
+    }
+    Ok(())
+}

--- a/crates/pensieve-lake/src/catalog.rs
+++ b/crates/pensieve-lake/src/catalog.rs
@@ -1,0 +1,1002 @@
+//! Portable, deterministic snapshots of active raw lake objects.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{Error, Inventory, ObjectRecord, Result, WorkUnitRecord};
+
+/// Format identifier for V1 active-raw fragments and snapshots.
+pub const ACTIVE_RAW_CATALOG_FORMAT: &str = "pensieve.active-raw-catalog.v1";
+
+/// Published source-work coverage recorded in a catalog.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct CatalogWorkUnit {
+    /// Content-derived work-unit identifier.
+    pub work_unit_id: String,
+    /// Source filename for operator traceability, without its host-local path.
+    pub source_name: String,
+    /// Exact source bytes.
+    pub source_bytes: u64,
+    /// Lowercase SHA-256 of the source.
+    pub source_sha256: String,
+    /// Target represented bytes used by the writer.
+    pub target_uncompressed_bytes: u64,
+    /// Maximum accepted source frame bytes.
+    pub max_event_bytes: u64,
+    /// Object-key namespace used for this work.
+    pub object_prefix: String,
+    /// Writer implementation identity.
+    pub writer_version: String,
+    /// Source frames observed.
+    pub input_events: u64,
+    /// Canonical rows emitted.
+    pub output_rows: u64,
+    /// Source frames quarantined.
+    pub rejected_events: u64,
+}
+
+/// One immutable active raw Parquet object.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct CatalogObject {
+    /// Immutable key in the configured object store.
+    pub object_key: String,
+    /// Owning work unit.
+    pub work_unit_id: String,
+    /// Deterministic zero-based part number.
+    pub part_number: u32,
+    /// Exact object bytes.
+    pub byte_size: u64,
+    /// Lowercase SHA-256 of the object.
+    pub sha256: String,
+    /// Writer implementation identity.
+    pub writer_version: String,
+    /// Physical rows in this object.
+    pub row_count: u64,
+    /// Unsigned minimum event timestamp as decimal text.
+    pub min_created_at: Option<String>,
+    /// Unsigned maximum event timestamp as decimal text.
+    pub max_created_at: Option<String>,
+}
+
+/// Aggregate physical totals for a fragment or snapshot.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CatalogTotals {
+    /// Published source work units, including zero-output inputs.
+    pub work_units: u64,
+    /// Active raw Parquet objects.
+    pub objects: u64,
+    /// Sum of immutable object bytes.
+    pub object_bytes: u64,
+    /// Sum of physical rows; this is not a unique-event count.
+    pub physical_rows: u64,
+    /// Sum of quarantined source frames across covered work units.
+    pub rejected_events: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct FragmentPayload {
+    format: String,
+    store_id: String,
+    inventory_id: String,
+    object_class: String,
+    deduplicated_by_event_id: bool,
+    work_units: Vec<CatalogWorkUnit>,
+    objects: Vec<CatalogObject>,
+    totals: CatalogTotals,
+}
+
+/// Portable export from one writer's local inventory.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ActiveRawFragment {
+    /// SHA-256 content identity of the canonical fragment payload.
+    pub fragment_id: String,
+    #[serde(flatten)]
+    payload: FragmentPayload,
+}
+
+impl ActiveRawFragment {
+    /// Export the current published/active view from one inventory.
+    pub fn export(
+        inventory: &mut Inventory,
+        inventory_id: impl Into<String>,
+        store_id: impl Into<String>,
+    ) -> Result<Self> {
+        let (work_units, objects) = inventory.active_raw_catalog_records()?;
+        let work_units = work_units.into_iter().map(CatalogWorkUnit::from).collect();
+        let objects = objects.into_iter().map(CatalogObject::from).collect();
+        Self::from_records(inventory_id.into(), store_id.into(), work_units, objects)
+    }
+
+    fn from_records(
+        inventory_id: String,
+        store_id: String,
+        mut work_units: Vec<CatalogWorkUnit>,
+        mut objects: Vec<CatalogObject>,
+    ) -> Result<Self> {
+        validate_label("inventory_id", &inventory_id)?;
+        validate_label("store_id", &store_id)?;
+        work_units.sort();
+        objects.sort_by(|left, right| left.object_key.cmp(&right.object_key));
+        let totals = catalog_totals(&work_units, &objects)?;
+        let payload = FragmentPayload {
+            format: ACTIVE_RAW_CATALOG_FORMAT.to_owned(),
+            store_id,
+            inventory_id,
+            object_class: "active_raw".to_owned(),
+            deduplicated_by_event_id: false,
+            work_units,
+            objects,
+            totals,
+        };
+        validate_fragment_payload(&payload)?;
+        let fragment_id = content_id(&payload)?;
+        Ok(Self {
+            fragment_id,
+            payload,
+        })
+    }
+
+    /// Stable operator-defined identity for the exporting inventory.
+    pub fn inventory_id(&self) -> &str {
+        &self.payload.inventory_id
+    }
+
+    /// Stable non-secret identity for the shared object store.
+    pub fn store_id(&self) -> &str {
+        &self.payload.store_id
+    }
+
+    /// Published source work included in this fragment.
+    pub fn work_units(&self) -> &[CatalogWorkUnit] {
+        &self.payload.work_units
+    }
+
+    /// Active raw objects included in this fragment.
+    pub fn objects(&self) -> &[CatalogObject] {
+        &self.payload.objects
+    }
+
+    /// Aggregate physical totals.
+    pub fn totals(&self) -> &CatalogTotals {
+        &self.payload.totals
+    }
+
+    /// Verify structure, ordering, references, totals, and content identity.
+    pub fn validate(&self) -> Result<()> {
+        validate_fragment_payload(&self.payload)?;
+        validate_content_id("fragment", &self.fragment_id, &self.payload)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+struct SnapshotSource {
+    inventory_id: String,
+    fragment_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct SnapshotPayload {
+    format: String,
+    store_id: String,
+    object_class: String,
+    deduplicated_by_event_id: bool,
+    sources: Vec<SnapshotSource>,
+    work_units: Vec<CatalogWorkUnit>,
+    objects: Vec<CatalogObject>,
+    totals: CatalogTotals,
+}
+
+/// Deterministic union of one or more active-raw inventory fragments.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ActiveRawSnapshot {
+    /// SHA-256 content identity of the canonical snapshot payload.
+    pub snapshot_id: String,
+    #[serde(flatten)]
+    payload: SnapshotPayload,
+}
+
+impl ActiveRawSnapshot {
+    /// Stable non-secret identity for the shared object store.
+    pub fn store_id(&self) -> &str {
+        &self.payload.store_id
+    }
+
+    /// Active raw objects included in this snapshot.
+    pub fn objects(&self) -> &[CatalogObject] {
+        &self.payload.objects
+    }
+
+    /// Published work-unit coverage included in this snapshot.
+    pub fn work_units(&self) -> &[CatalogWorkUnit] {
+        &self.payload.work_units
+    }
+
+    /// Aggregate physical totals.
+    pub fn totals(&self) -> &CatalogTotals {
+        &self.payload.totals
+    }
+
+    /// Verify structure, ordering, references, totals, and content identity.
+    pub fn validate(&self) -> Result<()> {
+        validate_snapshot_payload(&self.payload)?;
+        validate_content_id("snapshot", &self.snapshot_id, &self.payload)
+    }
+}
+
+/// Merge independently exported inventory fragments into one active-file snapshot.
+pub fn merge_active_raw_fragments(
+    fragments: impl IntoIterator<Item = ActiveRawFragment>,
+) -> Result<ActiveRawSnapshot> {
+    let mut fragments: Vec<_> = fragments.into_iter().collect();
+    if fragments.is_empty() {
+        return Err(Error::InvalidCatalog(
+            "at least one inventory fragment is required".to_owned(),
+        ));
+    }
+    for fragment in &fragments {
+        fragment.validate()?;
+    }
+    fragments.sort_by(|left, right| {
+        left.inventory_id()
+            .cmp(right.inventory_id())
+            .then(left.fragment_id.cmp(&right.fragment_id))
+    });
+
+    let store_id = fragments[0].store_id().to_owned();
+    let mut sources = BTreeMap::<String, String>::new();
+    let mut work_units = BTreeMap::<String, CatalogWorkUnit>::new();
+    let mut work_object_sets = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut objects = BTreeMap::<String, CatalogObject>::new();
+    let mut parts = BTreeMap::<(String, u32), String>::new();
+
+    for fragment in fragments {
+        if fragment.store_id() != store_id {
+            return Err(Error::InvalidCatalog(format!(
+                "fragment {} uses store {}, expected {}",
+                fragment.fragment_id,
+                fragment.store_id(),
+                store_id
+            )));
+        }
+        match sources.get(fragment.inventory_id()) {
+            Some(existing) if existing != &fragment.fragment_id => {
+                return Err(Error::InvalidCatalog(format!(
+                    "inventory {} appears with conflicting fragment identities",
+                    fragment.inventory_id()
+                )));
+            }
+            _ => {
+                sources.insert(
+                    fragment.inventory_id().to_owned(),
+                    fragment.fragment_id.clone(),
+                );
+            }
+        }
+
+        let fragment_object_sets = object_sets(fragment.objects());
+        for work_unit in fragment.work_units() {
+            if let Some(existing) = work_units.get(&work_unit.work_unit_id) {
+                if existing != work_unit
+                    || work_object_sets.get(&work_unit.work_unit_id)
+                        != fragment_object_sets.get(&work_unit.work_unit_id)
+                {
+                    return Err(Error::InvalidCatalog(format!(
+                        "work unit {} has conflicting records across fragments",
+                        work_unit.work_unit_id
+                    )));
+                }
+            } else {
+                work_units.insert(work_unit.work_unit_id.clone(), work_unit.clone());
+                work_object_sets.insert(
+                    work_unit.work_unit_id.clone(),
+                    fragment_object_sets
+                        .get(&work_unit.work_unit_id)
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+            }
+        }
+        for object in fragment.objects() {
+            let part = (object.work_unit_id.clone(), object.part_number);
+            if let Some(existing_key) = parts.get(&part) {
+                if existing_key != &object.object_key {
+                    return Err(Error::InvalidCatalog(format!(
+                        "work unit {} part {} maps to conflicting object keys",
+                        object.work_unit_id, object.part_number
+                    )));
+                }
+            } else {
+                parts.insert(part, object.object_key.clone());
+            }
+            if let Some(existing) = objects.get(&object.object_key) {
+                if existing != object {
+                    return Err(Error::InvalidCatalog(format!(
+                        "object key {} has conflicting metadata",
+                        object.object_key
+                    )));
+                }
+            } else {
+                objects.insert(object.object_key.clone(), object.clone());
+            }
+        }
+    }
+
+    let work_units: Vec<_> = work_units.into_values().collect();
+    let objects: Vec<_> = objects.into_values().collect();
+    let payload = SnapshotPayload {
+        format: ACTIVE_RAW_CATALOG_FORMAT.to_owned(),
+        store_id,
+        object_class: "active_raw".to_owned(),
+        deduplicated_by_event_id: false,
+        sources: sources
+            .into_iter()
+            .map(|(inventory_id, fragment_id)| SnapshotSource {
+                inventory_id,
+                fragment_id,
+            })
+            .collect(),
+        totals: catalog_totals(&work_units, &objects)?,
+        work_units,
+        objects,
+    };
+    validate_snapshot_payload(&payload)?;
+    let snapshot_id = content_id(&payload)?;
+    Ok(ActiveRawSnapshot {
+        snapshot_id,
+        payload,
+    })
+}
+
+/// Read and validate one inventory fragment.
+pub fn read_catalog_fragment(path: impl AsRef<Path>) -> Result<ActiveRawFragment> {
+    let bytes = fs::read(path)?;
+    let fragment = serde_json::from_slice(&bytes)?;
+    ActiveRawFragment::validate(&fragment)?;
+    validate_canonical_json(&bytes, &fragment)?;
+    Ok(fragment)
+}
+
+/// Read and validate one merged active-file snapshot.
+pub fn read_catalog_snapshot(path: impl AsRef<Path>) -> Result<ActiveRawSnapshot> {
+    let bytes = fs::read(path)?;
+    let snapshot = serde_json::from_slice(&bytes)?;
+    ActiveRawSnapshot::validate(&snapshot)?;
+    validate_canonical_json(&bytes, &snapshot)?;
+    Ok(snapshot)
+}
+
+/// Atomically replace a catalog JSON file with canonical pretty-printed bytes.
+pub fn write_catalog_atomically<T: Serialize>(path: impl AsRef<Path>, value: &T) -> Result<()> {
+    let path = path.as_ref();
+    let parent = path.parent().filter(|path| !path.as_os_str().is_empty());
+    let parent = parent.unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    temporary.write_all(&canonical_json(value)?)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary
+        .persist(path)
+        .map_err(|error| Error::Io(error.error))?;
+    File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn canonical_json(value: &impl Serialize) -> Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn validate_canonical_json(bytes: &[u8], value: &impl Serialize) -> Result<()> {
+    if bytes != canonical_json(value)? {
+        return Err(Error::InvalidCatalog(
+            "catalog JSON is valid but not canonically encoded".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_fragment_payload(payload: &FragmentPayload) -> Result<()> {
+    validate_common(
+        &payload.format,
+        &payload.store_id,
+        &payload.object_class,
+        payload.deduplicated_by_event_id,
+        &payload.work_units,
+        &payload.objects,
+        &payload.totals,
+    )?;
+    validate_label("inventory_id", &payload.inventory_id)
+}
+
+fn validate_snapshot_payload(payload: &SnapshotPayload) -> Result<()> {
+    validate_common(
+        &payload.format,
+        &payload.store_id,
+        &payload.object_class,
+        payload.deduplicated_by_event_id,
+        &payload.work_units,
+        &payload.objects,
+        &payload.totals,
+    )?;
+    if payload.sources.is_empty() {
+        return Err(Error::InvalidCatalog(
+            "snapshot has no source fragments".to_owned(),
+        ));
+    }
+    ensure_sorted_unique(&payload.sources, "snapshot sources")?;
+    let inventory_ids: BTreeSet<_> = payload
+        .sources
+        .iter()
+        .map(|source| source.inventory_id.as_str())
+        .collect();
+    if inventory_ids.len() != payload.sources.len() {
+        return Err(Error::InvalidCatalog(
+            "snapshot source inventory identifiers are not unique".to_owned(),
+        ));
+    }
+    for source in &payload.sources {
+        validate_label("source inventory_id", &source.inventory_id)?;
+        validate_sha256_id("source fragment_id", &source.fragment_id)?;
+    }
+    Ok(())
+}
+
+fn validate_common(
+    format: &str,
+    store_id: &str,
+    object_class: &str,
+    deduplicated_by_event_id: bool,
+    work_units: &[CatalogWorkUnit],
+    objects: &[CatalogObject],
+    totals: &CatalogTotals,
+) -> Result<()> {
+    if format != ACTIVE_RAW_CATALOG_FORMAT {
+        return Err(Error::InvalidCatalog(format!(
+            "unsupported format {format}"
+        )));
+    }
+    validate_label("store_id", store_id)?;
+    if object_class != "active_raw" {
+        return Err(Error::InvalidCatalog(format!(
+            "unsupported object class {object_class}"
+        )));
+    }
+    if deduplicated_by_event_id {
+        return Err(Error::InvalidCatalog(
+            "V1 active-raw catalogs cannot claim event-ID deduplication".to_owned(),
+        ));
+    }
+    ensure_sorted_unique(work_units, "work units")?;
+    ensure_sorted_object_keys(objects)?;
+    let work_by_id: BTreeMap<_, _> = work_units
+        .iter()
+        .map(|work| (work.work_unit_id.as_str(), work))
+        .collect();
+    if work_by_id.len() != work_units.len() {
+        return Err(Error::InvalidCatalog(
+            "work-unit identifiers are not unique".to_owned(),
+        ));
+    }
+    let mut parts = BTreeSet::new();
+    let mut work_parts = BTreeMap::<&str, BTreeSet<u32>>::new();
+    let mut work_rows = BTreeMap::<&str, u64>::new();
+    for work in work_units {
+        validate_label("work_unit_id", &work.work_unit_id)?;
+        validate_label("source_name", &work.source_name)?;
+        validate_label("object_prefix", &work.object_prefix)?;
+        validate_label("work-unit writer_version", &work.writer_version)?;
+        validate_sha256_hex("source_sha256", &work.source_sha256)?;
+        if work.source_name.contains('/') || work.source_name.contains('\\') {
+            return Err(Error::InvalidCatalog(format!(
+                "source_name contains a path separator: {}",
+                work.source_name
+            )));
+        }
+        if work
+            .output_rows
+            .checked_add(work.rejected_events)
+            .is_none_or(|accounted| accounted > work.input_events)
+        {
+            return Err(Error::InvalidCatalog(format!(
+                "work unit {} accounts for more rows and rejects than its inputs",
+                work.work_unit_id
+            )));
+        }
+    }
+    for object in objects {
+        validate_label("object_key", &object.object_key)?;
+        validate_label("object writer_version", &object.writer_version)?;
+        validate_sha256_hex("object sha256", &object.sha256)?;
+        let Some(work) = work_by_id.get(object.work_unit_id.as_str()) else {
+            return Err(Error::InvalidCatalog(format!(
+                "object {} references absent work unit {}",
+                object.object_key, object.work_unit_id
+            )));
+        };
+        if object.writer_version != work.writer_version {
+            return Err(Error::InvalidCatalog(format!(
+                "object {} has a different writer identity than work unit {}",
+                object.object_key, object.work_unit_id
+            )));
+        }
+        let expected_prefix = format!("{}/", work.object_prefix.trim_end_matches('/'));
+        if !object.object_key.starts_with(&expected_prefix) {
+            return Err(Error::InvalidCatalog(format!(
+                "object {} is outside work unit {} prefix {}",
+                object.object_key, object.work_unit_id, work.object_prefix
+            )));
+        }
+        if !parts.insert((&object.work_unit_id, object.part_number)) {
+            return Err(Error::InvalidCatalog(format!(
+                "work unit {} has duplicate part {}",
+                object.work_unit_id, object.part_number
+            )));
+        }
+        work_parts
+            .entry(&object.work_unit_id)
+            .or_default()
+            .insert(object.part_number);
+        let rows = work_rows.entry(&object.work_unit_id).or_default();
+        *rows = rows.checked_add(object.row_count).ok_or_else(|| {
+            Error::InvalidCatalog(format!(
+                "work unit {} object row count overflows u64",
+                object.work_unit_id
+            ))
+        })?;
+        validate_range(object)?;
+    }
+    for work in work_units {
+        let object_rows = work_rows
+            .get(work.work_unit_id.as_str())
+            .copied()
+            .unwrap_or_default();
+        if object_rows != work.output_rows {
+            return Err(Error::InvalidCatalog(format!(
+                "work unit {} reports {} output rows but its objects contain {}",
+                work.work_unit_id, work.output_rows, object_rows
+            )));
+        }
+        if let Some(part_numbers) = work_parts.get(work.work_unit_id.as_str()) {
+            for (expected, actual) in (0_u32..).zip(part_numbers) {
+                if expected != *actual {
+                    return Err(Error::InvalidCatalog(format!(
+                        "work unit {} object parts are not contiguous from zero",
+                        work.work_unit_id
+                    )));
+                }
+            }
+        }
+    }
+    if &catalog_totals(work_units, objects)? != totals {
+        return Err(Error::InvalidCatalog(
+            "catalog totals do not match its records".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_range(object: &CatalogObject) -> Result<()> {
+    let min = object
+        .min_created_at
+        .as_deref()
+        .map(parse_canonical_u64)
+        .transpose()?;
+    let max = object
+        .max_created_at
+        .as_deref()
+        .map(parse_canonical_u64)
+        .transpose()?;
+    if object.row_count == 0 && (min.is_some() || max.is_some()) {
+        return Err(Error::InvalidCatalog(format!(
+            "empty object {} has an event-time range",
+            object.object_key
+        )));
+    }
+    if object.row_count > 0 && (min.is_none() || max.is_none()) {
+        return Err(Error::InvalidCatalog(format!(
+            "non-empty object {} lacks a complete event-time range",
+            object.object_key
+        )));
+    }
+    if min.zip(max).is_some_and(|(min, max)| min > max) {
+        return Err(Error::InvalidCatalog(format!(
+            "object {} has an inverted event-time range",
+            object.object_key
+        )));
+    }
+    Ok(())
+}
+
+fn parse_canonical_u64(value: &str) -> Result<u64> {
+    let parsed = value.parse::<u64>().map_err(|_| {
+        Error::InvalidCatalog(format!("invalid unsigned decimal timestamp {value}"))
+    })?;
+    if parsed.to_string() != value {
+        return Err(Error::InvalidCatalog(format!(
+            "non-canonical unsigned decimal timestamp {value}"
+        )));
+    }
+    Ok(parsed)
+}
+
+fn catalog_totals(
+    work_units: &[CatalogWorkUnit],
+    objects: &[CatalogObject],
+) -> Result<CatalogTotals> {
+    Ok(CatalogTotals {
+        work_units: usize_to_u64(work_units.len(), "work-unit count")?,
+        objects: usize_to_u64(objects.len(), "object count")?,
+        object_bytes: checked_sum(
+            objects.iter().map(|object| object.byte_size),
+            "object byte total",
+        )?,
+        physical_rows: checked_sum(
+            objects.iter().map(|object| object.row_count),
+            "physical row total",
+        )?,
+        rejected_events: checked_sum(
+            work_units.iter().map(|work| work.rejected_events),
+            "rejected event total",
+        )?,
+    })
+}
+
+fn checked_sum(mut values: impl Iterator<Item = u64>, field: &str) -> Result<u64> {
+    values.try_fold(0_u64, |total, value| {
+        total
+            .checked_add(value)
+            .ok_or_else(|| Error::InvalidCatalog(format!("{field} overflows u64")))
+    })
+}
+
+fn usize_to_u64(value: usize, field: &str) -> Result<u64> {
+    u64::try_from(value)
+        .map_err(|_| Error::InvalidCatalog(format!("{field} cannot be represented as u64")))
+}
+
+fn object_sets(objects: &[CatalogObject]) -> BTreeMap<String, BTreeSet<String>> {
+    let mut result = BTreeMap::<String, BTreeSet<String>>::new();
+    for object in objects {
+        result
+            .entry(object.work_unit_id.clone())
+            .or_default()
+            .insert(object.object_key.clone());
+    }
+    result
+}
+
+fn ensure_sorted_unique<T: Ord>(values: &[T], label: &str) -> Result<()> {
+    if values.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(Error::InvalidCatalog(format!(
+            "{label} are not strictly sorted and unique"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_sorted_object_keys(objects: &[CatalogObject]) -> Result<()> {
+    if objects
+        .windows(2)
+        .any(|pair| pair[0].object_key >= pair[1].object_key)
+    {
+        return Err(Error::InvalidCatalog(
+            "objects are not strictly sorted by key".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_label(field: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() || value.chars().any(char::is_control) {
+        return Err(Error::InvalidCatalog(format!(
+            "{field} must be non-empty and contain no control characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sha256_id(field: &str, value: &str) -> Result<()> {
+    let Some(digest) = value.strip_prefix("sha256:") else {
+        return Err(Error::InvalidCatalog(format!(
+            "{field} must start with sha256:"
+        )));
+    };
+    validate_sha256_hex(field, digest)
+}
+
+fn validate_sha256_hex(field: &str, value: &str) -> Result<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(Error::InvalidCatalog(format!(
+            "{field} must be 64 lowercase hexadecimal characters"
+        )));
+    }
+    Ok(())
+}
+
+fn content_id(value: &impl Serialize) -> Result<String> {
+    let bytes = serde_json::to_vec(value)?;
+    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+fn validate_content_id(label: &str, actual: &str, payload: &impl Serialize) -> Result<()> {
+    validate_sha256_id(&format!("{label}_id"), actual)?;
+    let expected = content_id(payload)?;
+    if actual != expected {
+        return Err(Error::InvalidCatalog(format!(
+            "{label} identity mismatch: expected {expected}, found {actual}"
+        )));
+    }
+    Ok(())
+}
+
+impl From<WorkUnitRecord> for CatalogWorkUnit {
+    fn from(record: WorkUnitRecord) -> Self {
+        let source_name = record
+            .source_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| record.source_path.to_string_lossy().into_owned());
+        Self {
+            work_unit_id: record.id,
+            source_name,
+            source_bytes: record.source_bytes,
+            source_sha256: record.source_sha256,
+            target_uncompressed_bytes: record.target_uncompressed_bytes,
+            max_event_bytes: record.max_event_bytes,
+            object_prefix: record.object_prefix,
+            writer_version: record.writer_version,
+            input_events: record.input_events,
+            output_rows: record.output_rows,
+            rejected_events: record.rejected_events,
+        }
+    }
+}
+
+impl From<ObjectRecord> for CatalogObject {
+    fn from(record: ObjectRecord) -> Self {
+        Self {
+            object_key: record.object_key,
+            work_unit_id: record.work_unit_id,
+            part_number: record.part_number,
+            byte_size: record.byte_size,
+            sha256: record.sha256,
+            writer_version: record.writer_version,
+            row_count: record.row_count,
+            min_created_at: record.min_created_at.map(|value| value.to_string()),
+            max_created_at: record.max_created_at.map(|value| value.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ObjectKind, ObjectState, WorkState, WorkUnitRegistration};
+
+    fn work(id: &str) -> CatalogWorkUnit {
+        CatalogWorkUnit {
+            work_unit_id: id.to_owned(),
+            source_name: format!("{id}.notepack.gz"),
+            source_bytes: 100,
+            source_sha256: "11".repeat(32),
+            target_uncompressed_bytes: 1_000,
+            max_event_bytes: 2_000,
+            object_prefix: "nostr/v1".to_owned(),
+            writer_version: "test-writer".to_owned(),
+            input_events: 2,
+            output_rows: 2,
+            rejected_events: 0,
+        }
+    }
+
+    fn object(work_unit_id: &str, key: &str, part_number: u32) -> CatalogObject {
+        CatalogObject {
+            object_key: format!("nostr/v1/{key}"),
+            work_unit_id: work_unit_id.to_owned(),
+            part_number,
+            byte_size: 50,
+            sha256: "22".repeat(32),
+            writer_version: "test-writer".to_owned(),
+            row_count: 2,
+            min_created_at: Some("1".to_owned()),
+            max_created_at: Some(u64::MAX.to_string()),
+        }
+    }
+
+    fn fragment(inventory_id: &str, work_id: &str, key: &str) -> ActiveRawFragment {
+        ActiveRawFragment::from_records(
+            inventory_id.to_owned(),
+            "s3://test".to_owned(),
+            vec![work(work_id)],
+            vec![object(work_id, key, 0)],
+        )
+        .expect("valid fragment")
+    }
+
+    #[test]
+    fn merge_is_deterministic_across_fragment_order() {
+        let first = fragment("history", "work-a", "raw/a.parquet");
+        let second = fragment("live", "work-b", "raw/b.parquet");
+        let forward =
+            merge_active_raw_fragments([first.clone(), second.clone()]).expect("forward merge");
+        let reverse = merge_active_raw_fragments([second, first]).expect("reverse merge");
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward.totals().work_units, 2);
+        assert_eq!(forward.totals().objects, 2);
+        assert_eq!(forward.totals().physical_rows, 4);
+        forward.validate().expect("valid snapshot");
+    }
+
+    #[test]
+    fn identical_fragments_are_idempotent() {
+        let fragment = fragment("history", "work-a", "raw/a.parquet");
+        let once = merge_active_raw_fragments([fragment.clone()]).expect("single merge");
+        let twice =
+            merge_active_raw_fragments([fragment.clone(), fragment]).expect("duplicate merge");
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn conflicting_object_key_is_rejected() {
+        let first = fragment("history", "work-a", "raw/shared.parquet");
+        let mut second = fragment("live", "work-b", "raw/shared.parquet");
+        second.payload.objects[0].sha256 = "33".repeat(32);
+        second.fragment_id = content_id(&second.payload).expect("new identity");
+
+        let error = merge_active_raw_fragments([first, second]).expect_err("must conflict");
+        assert!(error.to_string().contains("conflicting metadata"));
+    }
+
+    #[test]
+    fn noncanonical_unsigned_timestamp_is_rejected() {
+        let mut fragment = fragment("history", "work-a", "raw/a.parquet");
+        fragment.payload.objects[0].min_created_at = Some("01".to_owned());
+        fragment.fragment_id = content_id(&fragment.payload).expect("new identity");
+
+        let error = fragment.validate().expect_err("must reject");
+        assert!(error.to_string().contains("non-canonical"));
+    }
+
+    #[test]
+    fn content_identity_detects_tampering() {
+        let mut fragment = fragment("history", "work-a", "raw/a.parquet");
+        fragment.payload.objects[0].byte_size += 1;
+
+        let error = fragment.validate().expect_err("must reject");
+        assert!(error.to_string().contains("totals do not match"));
+    }
+
+    #[test]
+    fn work_unit_rows_must_match_its_active_objects() {
+        let mut fragment = fragment("history", "work-a", "raw/a.parquet");
+        fragment.payload.work_units[0].output_rows = 1;
+        fragment.fragment_id = content_id(&fragment.payload).expect("new identity");
+
+        let error = fragment.validate().expect_err("must reject");
+        assert!(error.to_string().contains("reports 1 output rows"));
+    }
+
+    #[test]
+    fn atomic_json_round_trip_preserves_snapshot() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("snapshot.json");
+        let snapshot = merge_active_raw_fragments([fragment("history", "work-a", "raw/a.parquet")])
+            .expect("snapshot");
+
+        write_catalog_atomically(&path, &snapshot).expect("write");
+        assert_eq!(read_catalog_snapshot(&path).expect("read"), snapshot);
+    }
+
+    #[test]
+    fn reader_rejects_noncanonical_json_bytes() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("snapshot.json");
+        let snapshot = merge_active_raw_fragments([fragment("history", "work-a", "raw/a.parquet")])
+            .expect("snapshot");
+        fs::write(&path, serde_json::to_vec(&snapshot).expect("compact JSON")).expect("write");
+
+        let error = read_catalog_snapshot(&path).expect_err("must reject");
+        assert!(error.to_string().contains("not canonically encoded"));
+    }
+
+    #[test]
+    fn inventory_export_includes_only_published_coverage_and_active_raw_objects() {
+        let mut inventory = Inventory::open_in_memory().expect("inventory");
+        publish_inventory_work(&mut inventory, "published", true);
+        publish_inventory_work(&mut inventory, "empty", false);
+        let failed_sha = "44".repeat(32);
+        inventory
+            .ensure_work_unit(&WorkUnitRegistration {
+                id: "failed",
+                source_path: Path::new("/source/failed.notepack.gz"),
+                source_bytes: 20,
+                source_sha256: &failed_sha,
+                target_uncompressed_bytes: 1_000,
+                max_event_bytes: 2_000,
+                object_prefix: "nostr/v1",
+                writer_version: "test-writer",
+            })
+            .expect("register failed work");
+        inventory
+            .transition_work("failed", WorkState::Writing, None)
+            .expect("start failed work");
+        inventory
+            .transition_work("failed", WorkState::Failed, Some("test failure"))
+            .expect("fail work");
+
+        let fragment = ActiveRawFragment::export(&mut inventory, "test-inventory", "s3://test")
+            .expect("export");
+
+        assert_eq!(fragment.totals().work_units, 2);
+        assert_eq!(fragment.totals().objects, 1);
+        assert_eq!(fragment.work_units()[0].work_unit_id, "empty");
+        assert_eq!(fragment.work_units()[1].work_unit_id, "published");
+        assert_eq!(fragment.objects()[0].work_unit_id, "published");
+        fragment.validate().expect("valid fragment");
+    }
+
+    fn publish_inventory_work(inventory: &mut Inventory, id: &str, with_object: bool) {
+        let source_sha256 = "55".repeat(32);
+        inventory
+            .ensure_work_unit(&WorkUnitRegistration {
+                id,
+                source_path: &Path::new("/source").join(format!("{id}.notepack.gz")),
+                source_bytes: 100,
+                source_sha256: &source_sha256,
+                target_uncompressed_bytes: 1_000,
+                max_event_bytes: 2_000,
+                object_prefix: "nostr/v1",
+                writer_version: "test-writer",
+            })
+            .expect("register work");
+        inventory
+            .transition_work(id, WorkState::Writing, None)
+            .expect("start work");
+        let objects = with_object.then(|| ObjectRecord {
+            object_key: format!("nostr/v1/raw/{id}/part-00000.parquet"),
+            work_unit_id: id.to_owned(),
+            part_number: 0,
+            kind: ObjectKind::Parquet,
+            state: ObjectState::Validated,
+            local_path: Path::new("/staging").join(format!("{id}.parquet")),
+            byte_size: 50,
+            sha256: "66".repeat(32),
+            writer_version: "test-writer".to_owned(),
+            row_count: 2,
+            min_created_at: Some(1),
+            max_created_at: Some(u64::MAX),
+        });
+        inventory
+            .record_validated_objects(
+                id,
+                u64::from(with_object) * 2,
+                u64::from(with_object) * 2,
+                0,
+                &objects.into_iter().collect::<Vec<_>>(),
+            )
+            .expect("validate work");
+        inventory
+            .transition_work(id, WorkState::Uploading, None)
+            .expect("start upload");
+        if with_object {
+            inventory
+                .mark_object_uploaded(&format!("nostr/v1/raw/{id}/part-00000.parquet"))
+                .expect("upload object");
+        }
+        inventory
+            .transition_work(id, WorkState::Uploaded, None)
+            .expect("finish upload");
+        inventory.activate_work_unit(id).expect("activate work");
+    }
+}

--- a/crates/pensieve-lake/src/error.rs
+++ b/crates/pensieve-lake/src/error.rs
@@ -18,6 +18,10 @@ pub enum Error {
     #[error("inventory database error: {0}")]
     Sqlite(#[from] rusqlite::Error),
 
+    /// Catalog JSON encoding or decoding failed.
+    #[error("catalog JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
     /// Canonical Parquet processing failed.
     #[error("Parquet archive error: {0}")]
     Parquet(#[from] pensieve_parquet::Error),
@@ -86,4 +90,8 @@ pub enum Error {
         /// Logical field name.
         field: &'static str,
     },
+
+    /// A fragment or snapshot violates the catalog contract.
+    #[error("invalid lake catalog: {0}")]
+    InvalidCatalog(String),
 }

--- a/crates/pensieve-lake/src/inventory.rs
+++ b/crates/pensieve-lake/src/inventory.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, Transaction, params};
 
 use crate::{Error, Result};
 
@@ -270,6 +270,14 @@ impl Inventory {
     /// Create an isolated in-memory inventory.
     pub fn open_in_memory() -> Result<Self> {
         Self::from_connection(Connection::open_in_memory()?)
+    }
+
+    /// Open an existing inventory without permitting schema or data changes.
+    pub fn open_read_only(path: impl AsRef<Path>) -> Result<Self> {
+        let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        connection.pragma_update(None, "query_only", "ON")?;
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        Ok(Self { connection })
     }
 
     fn from_connection(connection: Connection) -> Result<Self> {
@@ -632,6 +640,49 @@ impl Inventory {
             .query_map([], object_from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(records)
+    }
+
+    /// Read one consistent catalog view of published work and active raw objects.
+    ///
+    /// Published work units with no Parquet objects are included so the catalog
+    /// can record coverage of empty but successfully processed inputs.
+    pub fn active_raw_catalog_records(
+        &mut self,
+    ) -> Result<(Vec<WorkUnitRecord>, Vec<ObjectRecord>)> {
+        let transaction = self.connection.transaction()?;
+        let work_units = {
+            let mut statement = transaction.prepare(
+                r#"
+                SELECT id, source_path, source_bytes, source_sha256,
+                       target_uncompressed_bytes, max_event_bytes, object_prefix,
+                       writer_version, state, input_events, output_rows,
+                       rejected_events, error
+                FROM work_units
+                WHERE state IN ('published', 'source_committed')
+                ORDER BY id
+                "#,
+            )?;
+            statement
+                .query_map([], work_unit_from_row)?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        let objects = {
+            let mut statement = transaction.prepare(
+                r#"
+                SELECT object_key, work_unit_id, part_number, kind, state,
+                       local_path, byte_size, sha256, writer_version, row_count,
+                       min_created_at, max_created_at
+                FROM objects
+                WHERE state = 'active_raw' AND kind = 'parquet'
+                ORDER BY object_key
+                "#,
+            )?;
+            statement
+                .query_map([], object_from_row)?
+                .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+        transaction.commit()?;
+        Ok((work_units, objects))
     }
 }
 

--- a/crates/pensieve-lake/src/lib.rs
+++ b/crates/pensieve-lake/src/lib.rs
@@ -4,11 +4,17 @@
 //! `pensieve-parquet`. This crate owns resumability and the external facts that
 //! deliberately do not belong in canonical file metadata.
 
+mod catalog;
 mod error;
 mod inventory;
 mod publisher;
 mod work_unit;
 
+pub use catalog::{
+    ACTIVE_RAW_CATALOG_FORMAT, ActiveRawFragment, ActiveRawSnapshot, CatalogObject, CatalogTotals,
+    CatalogWorkUnit, merge_active_raw_fragments, read_catalog_fragment, read_catalog_snapshot,
+    write_catalog_atomically,
+};
 pub use error::{Error, Result};
 pub use inventory::{
     Inventory, ObjectKind, ObjectRecord, ObjectState, WorkState, WorkUnitRecord,

--- a/docs/lake_active_file_catalog.md
+++ b/docs/lake_active_file_catalog.md
@@ -1,0 +1,181 @@
+# Active-file lake catalog
+
+*Status: implemented P2 foundation; active raw objects only*
+
+This catalog gives a reader one explicit, immutable view of the Parquet files
+that make up Pensieve's logical raw lake. It unifies the independently updated
+SQLite inventories used by the historical campaign, the production live
+shadow, and repair/import jobs without making those host-local databases a
+distributed database.
+
+The catalog is external operational metadata. It does not change the canonical
+Parquet V1 schema or add footer metadata.
+
+## Model
+
+There are three layers:
+
+1. Every writer keeps its existing SQLite publication journal and inventory.
+   Only work units in `published` or `source_committed` state and Parquet
+   objects in `active_raw` state are visible.
+2. `pensieve-lake-catalog export` takes one consistent, read-only SQLite
+   snapshot and writes a portable **fragment**.
+3. `pensieve-lake-catalog merge` validates and deterministically unions one or
+   more fragments into an immutable **active-file snapshot**.
+
+A fragment includes published zero-output work units as well as work units with
+objects. This makes a successfully processed empty input visible as coverage
+instead of making it indistinguishable from an input that was never processed.
+Failed, writing, uploading, quarantined, and otherwise incomplete work never
+enters a fragment.
+
+The V1 catalog covers active raw objects only. It sets
+`deduplicated_by_event_id` to `false`, because independent raw files may contain
+the same Nostr event ID. A reader must union/group by `id` and apply the
+canonical signature-variant rule. `physical_rows` is useful for auditing I/O;
+it is not a unique-event count.
+
+## Identity and deterministic bytes
+
+The format identifier is `pensieve.active-raw-catalog.v1`.
+
+Each fragment records:
+
+- a non-secret `store_id` shared by every participating inventory;
+- a unique operator-assigned `inventory_id`;
+- every published work unit's source name, checksum, byte size, conversion
+  settings, writer identity, and input/output/reject counts;
+- every active raw object's key, owning work unit and part, checksum, byte size,
+  physical rows, writer identity, and unsigned event-time range; and
+- checked aggregate totals.
+
+Unsigned `created_at` minima and maxima are canonical decimal strings so the
+full `u64` domain survives JSON consumers that cannot safely represent large
+integers.
+
+Records are strictly sorted. A fragment ID is SHA-256 over its canonical
+payload. A snapshot ID is SHA-256 over its canonical payload, including the
+sorted source fragment identities. There is deliberately no generation
+timestamp: identical inventory states produce identical logical IDs and
+identical JSON bytes. Readers require the tool's pretty-printed UTF-8 encoding
+with one trailing newline; reformatting otherwise valid JSON is rejected. This
+ensures one snapshot ID cannot be published with multiple byte representations.
+
+Fragments do not need a cross-host transaction or matching wall-clock instant.
+The merged snapshot is an exact selected object set, not a claim that collection
+was complete at a timestamp. A coordinated P2d parity checkpoint still records
+its own ingest barrier and verifies the selected union through that barrier.
+
+Merge rejects:
+
+- fragments for different object stores;
+- one `inventory_id` with different fragment identities;
+- one work-unit ID with different metadata or a different object set;
+- one object key with different metadata;
+- one work-unit part mapped to different object keys;
+- missing work-unit references, invalid checksums or unsigned ranges;
+- unsorted/duplicate records, incorrect totals, or a content-ID mismatch.
+
+An identical fragment, work unit, or object may be supplied more than once and
+is idempotently collapsed.
+
+`store_id` must identify the full object-store namespace, not only a bucket
+name that might exist at multiple providers. Pensieve uses
+`s3+https://hel1.your-objectstorage.com/pensieve-parquet`; it contains no
+credentials.
+
+## Operation
+
+Build the release binary on each machine that owns an inventory. Exporting is
+read-only and can run while its writer is active:
+
+```bash
+# Production live shadow and repair work
+just lake-catalog export \
+  --inventory /archive/segments/.parquet-shadow/inventory.sqlite \
+  --inventory-id production-live \
+  --store-id s3+https://hel1.your-objectstorage.com/pensieve-parquet \
+  --output /var/lib/pensieve-parquet/catalog/production-live.json
+
+# Historical conversion VM
+just lake-catalog export \
+  --inventory /var/lib/pensieve-parquet/state/campaign.sqlite \
+  --inventory-id historical-campaign \
+  --store-id s3+https://hel1.your-objectstorage.com/pensieve-parquet \
+  --output /var/lib/pensieve-parquet/catalog/historical-campaign.json
+```
+
+Copy the two fragments to one administrative host, then merge and verify them:
+
+```bash
+just lake-catalog merge \
+  --fragment historical-campaign.json \
+  --fragment production-live.json \
+  --output active-raw.json
+
+just lake-catalog verify --snapshot active-raw.json
+```
+
+The merge replaces its local output atomically. Publishing uses the same
+conditional, checksum-confirming immutable S3 machinery as Parquet objects:
+
+```bash
+just lake-catalog publish \
+  --snapshot active-raw.json \
+  --s3-bucket "$PENSIEVE_PARQUET_S3_BUCKET" \
+  --s3-region "$AWS_REGION" \
+  --s3-endpoint-url "$AWS_ENDPOINT_URL_S3" \
+  --s3-force-path-style
+```
+
+The object key is
+`nostr/v1/catalog/active-raw/<snapshot-id-hex>.json`. Publishing an identical
+snapshot is safe; different bytes can never replace that key. Credentials use
+the AWS SDK's normal environment/provider chain and never enter the catalog.
+
+There is intentionally no mutable `latest` pointer in V1. A reader or scheduled
+job selects an explicit snapshot ID, which makes a run reproducible and
+rollback a configuration change rather than an object rewrite. Pointer
+publication, retention policy, and scheduled refresh can be added with the
+analytics control plane.
+
+## Repairs and later compaction
+
+A repair/import goes through the ordinary campaign state machine and becomes a
+separate published work unit. If it uses an inventory already represented by a
+fragment, the next export automatically includes it. This is how the segment
+7703 recovery enters the unified snapshot; no existing object or fragment is
+edited.
+
+Compaction is not represented by V1. Before a compactor can activate
+replacements, the inventory and catalog need a later format/state extension
+that atomically selects compacted outputs while excluding every superseded
+input. Until then, all snapshots are raw and readers deduplicate by event ID.
+
+## Validation checkpoint
+
+On 2026-07-27, a smoke test exported consistent backups of the active historical
+and production-live inventories, merged them in both roles, and re-read the
+result through the validator. The test snapshot contained 1,031 published work
+units, 1,531 active objects, 246,933,708 physical rows, and 97,407,239,269
+object bytes. It was a transient validation artifact, not a stable `latest`
+snapshot; both inventories continued advancing.
+
+The first operational snapshot was then assembled from fresh consistent
+historical-campaign and production-live inventory backups plus the segment 7703
+repair inventory. It contains:
+
+- 1,082 published work units;
+- 1,597 active raw Parquet objects;
+- 255,696,331 physical rows; and
+- 102,813,011,702 object bytes.
+
+Its snapshot ID is
+`sha256:9168328eeca44916aac9c9fdfd2a0fee941da515d728337c17af6085b15993a6`.
+The exact 1,566,785-byte JSON was independently verified and conditionally
+published at
+`nostr/v1/catalog/active-raw/9168328eeca44916aac9c9fdfd2a0fee941da515d728337c17af6085b15993a6.json`;
+its file SHA-256 is
+`994854e3dbc65eaaea7099b5ee798888e264f73d9bd3f7b6aa0c44dc22421faf`.
+This is an immutable checkpoint, not a mutable completeness claim: the
+historical and live inventories continue to advance.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -463,6 +463,12 @@ size and orderly shutdown use the existing seal path. Any Parquet failure is
 recorded and logged but cannot fail or advance the authoritative notepack /
 RocksDB path.
 
+Recovery testing on 2026-07-27 also found that finite backfill processes could
+exit while a detached gzip job was still running. `SegmentWriter` now retains
+and joins every compression thread after the final seal and during drop, before
+final statistics are read or downstream publication/indexing queues are
+closed.
+
 #### P2c — Convert sealed notepack history
 
 - [x] Add a dedicated **sealed-notepack campaign binary**. It reads sealed notepack
@@ -498,11 +504,25 @@ set from uploaded to active raw. Local publication uses no-clobber atomic
 renames. S3-compatible publication uses conditional `PutObject`; retries and
 race recovery require a `HeadObject` size and SHA-256 metadata match. Local
 fault injection, real-segment replay, and a temporary Hetzner bucket round trip
-are green. The durable production bucket and production-host multipart /
-throughput decision remain before the historical campaign.
+are green. The durable production bucket is active and the sequential
+historical campaign is running on a dedicated in-network VM with bounded spool
+space and post-publication cleanup. Single-request uploads are sufficient for
+the present campaign; multipart upload and worker concurrency are deferred
+optimizations rather than migration prerequisites. Failed work remains in the
+journal and its source remains available for an idempotent retry. After the
+initial startup inventory completes, a catch-up pass must process any source
+segments that arrived after that inventory was captured.
 
 #### P2d — Converge and verify
 
+- [x] Build a deterministic **unified active-raw snapshot catalog** across the
+      historical campaign, production live shadow, and repair/import
+      inventories. Each writer exports a read-only portable fragment; a strict
+      merge produces one content-addressed snapshot containing published work
+      coverage and active raw object keys/checksums. Incomplete and quarantined
+      state is excluded. Conflicts fail closed, and snapshots explicitly state
+      that raw rows are not event-ID-deduplicated. See
+      `docs/lake_active_file_catalog.md`.
 - [ ] Verify every historical work unit against its sealed notepack input and
       periodically create a coordinated go-forward checkpoint by closing the
       current live batch and sealing the current notepack segment at the same
@@ -518,6 +538,16 @@ throughput decision remain before the historical campaign.
 - [ ] Run every §3 conformance check and fault-inject every publication-journal
       transition. Quarantined or incomplete objects must never enter an active
       query snapshot.
+
+Implementation checkpoint (2026-07-27): fragments from the historical
+campaign, production live shadow, and the segment 7703 repair inventory were
+merged, independently verified, and conditionally published as immutable
+snapshot
+`sha256:9168328eeca44916aac9c9fdfd2a0fee941da515d728337c17af6085b15993a6`.
+It selects 1,082 published work units, 1,597 active raw objects, 255,696,331
+physical rows, and 102,813,011,702 object bytes. This is a reproducible
+checkpoint while both ingestion paths continue, not the still-pending
+historical/live parity proof.
 
 **Gate:** all sealed notepack inputs through `H` and N sustained go-forward
 windows have complete ID-keyed parity; every active output passes the
@@ -539,12 +569,13 @@ shadow-only; authoritative notepack ingestion is unaffected.
       integers per rollup window in Postgres; then only "today so far" needs a live
       merge.) "Today so far" comes from the selected live buffer and/or live
       sketches; it does not require SQLite specifically.
-- [ ] Query an explicit **active-file snapshot** from the external object inventory.
-      A snapshot contains the active raw objects not covered by compaction plus
-      active compacted replacements; it must never contain both a compacted
-      output and the inputs it supersedes. Raw scans group by `id` unless the
-      selected snapshot is certified deduplicated. A sum of physical Parquet
-      rows is not an event count.
+- [ ] Extend and consume the explicit **active-file snapshot** when compaction
+      begins. The P2 foundation currently snapshots active raw objects only.
+      The compaction extension must contain the active raw objects not covered
+      by compaction plus active compacted replacements, and must never contain
+      both a compacted output and the inputs it supersedes. Raw scans group by
+      `id` unless the selected snapshot is certified deduplicated. A sum of
+      physical Parquet rows is not an event count.
 - [ ] Add the independent background **optimizer/compactor** only when file
       count or pruning performance warrants it. It:
   1. selects a bounded active input set from the inventory;
@@ -707,20 +738,31 @@ The diff harness (seeded in P0) is what makes cutovers trustworthy:
 
 ## 9. Status tracker
 
-- **P0 Foundation** — in progress (disk relief, archive-format acceptance, and
-  real Hetzner compatibility round trip done; durable production bucket,
-  verification harness, and backups pending)
+Updated 2026-07-27.
+
+- **P0 Foundation** — in progress (disk relief, archive-format acceptance,
+  durable production object storage, real Hetzner compatibility and
+  production-network round trips done; full verification automation and final
+  backup/retention policy pending)
 - **P1 Collection & coverage** — in progress (initial `e`/`q`
   reference-coverage ✅, NIP-66 catalog first slice ✅, catalog visibility
   gauges ✅, dynamic negentropy target augmentation ✅; multi-monitor trust,
   richer connection/reconciliation coverage, and windowed REQ pending)
-- **P2 Parquet archive** — in progress (shared V1 writer/validator, target-sized
-  resumable campaign, publication journal/inventory, immutable local/S3
-  publisher, sealed-notepack live shadow, and initial production-sized
-  conversion and real Hetzner round-trip benchmarks are implemented; durable S3
-  provisioning, multipart/production-host throughput, historical/live
-  high-water `H`, parity harness, production-host worker concurrency sizing,
-  and unsealed-buffer failure-domain proof remain)
+- **P2 Parquet archive** — in progress. Shared V1 writer/validator, resumable
+  target-sized campaign, publication journal/inventory, immutable S3
+  publication, sealed-notepack live shadow, repair publication, and the
+  deterministic unified active-raw snapshot catalog are implemented. The live
+  replay floor is segment 7703, establishing the historical boundary at
+  `H = 7702`. The sequential historical campaign is active on its dedicated VM;
+  transient upload failures remain safely retryable. Segment 7703 was sealed as
+  an empty gzip after a now-fixed seal/compression race. Its exact 21,972 event
+  IDs were preserved from RocksDB; exhaustive relay recovery found 4,833 valid
+  unique event bodies and left 17,139 IDs as an explicit known gap. The repair
+  was validated, published as a separate immutable Parquet work unit, restored
+  to ClickHouse, and included with the historical and live inventories in the
+  first operational unified snapshot. Campaign completion/catch-up, full
+  ID-keyed historical/live parity, coordinated go-forward windows, publication
+  fault coverage, and the post-P5 unsealed-buffer failure-domain proof remain.
 - **P3 Optimization + new analytics** — not started
 - **P4 Reader cutover** — not started
 - **P5 Parquet durability authority** — not started
@@ -733,6 +775,10 @@ secrets in `/etc/pensieve/pensieve.env`; production box cut over to the new layo
 
 ## Related
 - `docs/parquet_archive_format.md` — accepted canonical V1 specification
+- `docs/lake_active_file_catalog.md` — deterministic distributed-inventory
+  export, merge, verification, and immutable snapshot publication
+- `docs/segment_7703_recovery.md` — evidence, validation, repair publication,
+  and known-gap audit for the empty live segment incident
 - `docs/parquet_writer_benchmark.md` — first real-segment prototype measurement
 - Target-architecture design notes (the *what*)
 - `docs/ingestion_pipeline.md` — current pipeline architecture

--- a/docs/segment_7703_recovery.md
+++ b/docs/segment_7703_recovery.md
@@ -1,0 +1,116 @@
+# Segment 7703 recovery record
+
+*Status: repair published; recovery complete with a known unavailable-event gap*
+
+This is the durable audit record for the first production live-shadow segment,
+`segment-000007703.notepack.gz`.
+
+## Incident
+
+Segment 7703 was sealed as a valid but empty 20-byte gzip even though the
+ingester had accepted 21,972 events into that segment. Its Parquet shadow and
+ClickHouse indexing therefore also observed zero rows.
+
+The cause was a seal/compression race: the next open segment could reuse the
+path while asynchronous compression still referred to it. The segment state
+machine now reserves the next open path before the old path is handed to the
+sealer, and the frame-bounded notepack decoder fix is also deployed. Subsequent
+live segments have sealed, converted, published, and indexed normally.
+
+This incident does not change the historical/live boundary. The persisted live
+replay floor is 7703, so the historical campaign boundary remains `H = 7702`.
+Segment 7703 is repaired as a separate immutable work unit instead of editing
+the empty source or any already-published object.
+
+## Preserved evidence
+
+The production RocksDB index preserved the exact 21,972 event IDs, but its
+values intentionally contain no event bodies. Before any further work, the
+relevant SST and the extracted ID set were copied aside:
+
+- production SST:
+  `/data/rocksdb-recovery/segment-7703/029060.sst`;
+- exact target IDs:
+  `/data/rocksdb-recovery/segment-7703/event-ids.hex`;
+- target ID count: 21,972; and
+- target ID file SHA-256:
+  `12e159c9fd6ad764efa634398bbe3864643a79a617bf1e92d9f2ef511ba5b43e`.
+
+The same ID file and checksum are retained on the recovery VM under
+`/var/lib/pensieve-recovery/segment-7703/`. Production RocksDB is not edited and
+no deduplication keys are deleted.
+
+## Recovery and validation
+
+A resumable recovery job asked multiple public Nostr relays for the exact event
+IDs in progressively smaller batches. Every returned event had to:
+
+1. parse as a Nostr event;
+2. recompute to an ID in the preserved target set;
+3. pass BIP-340 signature verification; and
+4. be unique within the recovery output.
+
+The relay passes used 100-ID batches, then 20-ID batches, then an exact retry of
+every still-missing ID. The completed output was audited by sorting its IDs
+against the target file. The audit proved that the recovered and missing sets
+are unique and disjoint and that their union is exactly the 21,972 targets.
+
+The recovered JSONL was processed by the normal `backfill-jsonl` validation
+pipeline with an isolated temporary RocksDB index: 4,833 events entered and
+4,833 valid events were written, with zero invalid events and zero duplicates.
+The production RocksDB, live segment directory, and ClickHouse were not inputs
+to that conversion.
+
+That finite backfill exposed a second shutdown issue: gzip work ran in a
+detached thread, so the process could exit with a complete sealed `.notepack`
+source and an incomplete `.notepack.gz.open`. The incomplete temporary gzip was
+removed and the complete plain source was used for repair publication. The
+writer now tracks and joins every compression job before a finite process exits
+or downstream consumers finish.
+
+## Final result
+
+- Recovered valid unique events: **4,833**
+- Unrecovered target IDs: **17,139**
+- Recovered JSONL SHA-256:
+  `e46b20124e06795ab1615294c52696ae77a1e93ca10eecb19d39c4aeae3558d8`
+- Missing-ID file SHA-256:
+  `05cbb834edca0057fc83afad63699770c4917edace9db5a810306e8c1205e65c`
+- Recovery journal SHA-256:
+  `cc0bce01d824091b74a076308e7fef087468c4b405338047df0fe08fc4e5fd0b`
+- Complete repair notepack bytes: **15,724,645**
+- Complete repair notepack SHA-256:
+  `e5a95b499fd8bbd8bf731548a6b8fbb3d699a2450dadeab95959ed7cb978d549`
+- Repair work-unit ID:
+  `notepack-sha256-e5a95b499fd8bbd8bf731548a6b8fbb3d699a2450dadeab95959ed7cb978d549`
+- Active Parquet object:
+  `nostr/v1/raw/notepack-sha256-e5a95b499fd8bbd8bf731548a6b8fbb3d699a2450dadeab95959ed7cb978d549/part-00000-c395769c662e725b9e8b99402683404ab72be322f5e2b417e782ec8d7fbbcc36.parquet`
+- Parquet object: **4,833 rows**, **11,406,329 bytes**, SHA-256
+  `c395769c662e725b9e8b99402683404ab72be322f5e2b417e782ec8d7fbbcc36`
+- Parquet `created_at` range: `1762343413` through `1785165001`
+- Unified snapshot ID:
+  `sha256:9168328eeca44916aac9c9fdfd2a0fee941da515d728337c17af6085b15993a6`
+- Unified snapshot object:
+  `nostr/v1/catalog/active-raw/9168328eeca44916aac9c9fdfd2a0fee941da515d728337c17af6085b15993a6.json`
+
+The independent Parquet validator reopened the repair object and confirmed
+4,833 rows in one row group. Re-running publication was idempotent. An exact-ID
+ClickHouse audit found zero of the target events before repair indexing and
+4,833 rows / 4,833 unique IDs afterward.
+
+The full recovery evidence archive is retained on production at
+`/data/rocksdb-recovery/segment-7703/recovered-artifacts`:
+
+- recovery archive:
+  `segment-7703-recovery-artifacts.tar.gz`, SHA-256
+  `d595f59954fc2d75e782aa6462f3768d3e5771f8e87fe5ccc26bcf6022185733`;
+- catalog archive:
+  `catalog/final-catalog.tar.gz`, SHA-256
+  `fc5c186898ce79d3acf81ba826c4de6afc415996ca92d82d44240d4079592733`;
+  and
+- the catalog archive expands to the three source fragments and the exact
+  unified snapshot JSON.
+
+The 17,139 missing IDs remain an explicit known gap. An event body cannot be
+reconstructed from an ID alone; these unavailable events are retained in the
+audit instead of being fabricated or silently counted as recovered.

--- a/justfile
+++ b/justfile
@@ -49,6 +49,10 @@ parquet-interop:
 parquet-campaign *ARGS:
     cargo run -p pensieve-lake --bin pensieve-parquet-campaign -- {{ARGS}}
 
+# Export, merge, or verify deterministic active-file lake catalogs.
+lake-catalog *ARGS:
+    cargo run -p pensieve-lake --bin pensieve-lake-catalog -- {{ARGS}}
+
 # ============================================================================
 # Build
 # ============================================================================


### PR DESCRIPTION
## Summary

- export deterministic, read-only fragments from each lake inventory and strictly merge them into one immutable active-raw snapshot
- verify canonical JSON/content identities and publish snapshots through the existing conditional local/S3 publisher
- join background segment compression before finite writers exit or downstream consumers finish
- record the completed segment 7703 recovery and update the P2 migration status while leaving P3 analytics unstarted

## Operational checkpoint

- recovered and validated 4,833 of segment 7703’s 21,972 exact IDs; retained 17,139 unavailable IDs as an explicit audited gap
- published the repair as a separate 4,833-row immutable Parquet object and restored those rows to ClickHouse
- published unified snapshot sha256:9168328eeca44916aac9c9fdfd2a0fee941da515d728337c17af6085b15993a6 with 1,082 work units and 1,597 active objects

## Validation

- just precommit
- revalidated the exact three operational fragments and published snapshot with the final catalog validator