### PR TITLE
Freeze and audit the bounded historical campaign

### DIFF
--- a/crates/pensieve-lake/src/bin/pensieve-source-manifest.rs
+++ b/crates/pensieve-lake/src/bin/pensieve-source-manifest.rs
@@ -1,0 +1,168 @@
+//! Freeze, inspect, and audit bounded historical source manifests.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use pensieve_lake::{
+    ActiveRawFragment, HistoricalSourceManifest, Inventory, audit_historical_completion,
+    read_historical_source_manifest, write_catalog_atomically,
+    write_historical_source_manifest_noclobber,
+};
+
+#[derive(Debug, Parser)]
+#[command(about = "Manage the frozen historical notepack source universe")]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Freeze a bounded manifest from one `rclone lsjson` capture.
+    Build {
+        /// JSON file produced by `rclone lsjson`.
+        #[arg(long)]
+        rclone_lsjson: PathBuf,
+        /// Inclusive historical segment boundary.
+        #[arg(long)]
+        max_segment_number: u64,
+        /// Immutable manifest destination; an existing file is never replaced.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Verify and summarize one frozen manifest.
+    Verify {
+        /// Canonical source manifest.
+        #[arg(long)]
+        manifest: PathBuf,
+        /// Optional operator-configured boundary that must match the manifest.
+        #[arg(long)]
+        expected_max_segment_number: Option<u64>,
+    },
+    /// Emit validated entries as tab-separated source name and bytes.
+    Entries {
+        /// Canonical source manifest.
+        #[arg(long)]
+        manifest: PathBuf,
+    },
+    /// Audit manifest coverage against a campaign inventory.
+    Audit {
+        /// Canonical source manifest.
+        #[arg(long)]
+        manifest: PathBuf,
+        /// Existing SQLite campaign inventory.
+        #[arg(long)]
+        inventory: PathBuf,
+        /// Canonical JSON audit-report destination.
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("source manifest failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    match Args::parse().command {
+        Command::Build {
+            rclone_lsjson,
+            max_segment_number,
+            output,
+        } => {
+            let bytes = std::fs::read(rclone_lsjson)?;
+            let manifest =
+                HistoricalSourceManifest::from_rclone_lsjson(&bytes, max_segment_number)?;
+            write_historical_source_manifest_noclobber(output, &manifest)?;
+            print_manifest(&manifest);
+        }
+        Command::Verify {
+            manifest,
+            expected_max_segment_number,
+        } => {
+            let manifest = read_historical_source_manifest(manifest)?;
+            if let Some(expected) = expected_max_segment_number
+                && expected != manifest.max_segment_number()
+            {
+                return Err(format!(
+                    "manifest boundary {} does not match configured boundary {expected}",
+                    manifest.max_segment_number()
+                )
+                .into());
+            }
+            print_manifest(&manifest);
+        }
+        Command::Entries { manifest } => {
+            let manifest = read_historical_source_manifest(manifest)?;
+            for entry in manifest.entries() {
+                println!("{}\t{}", entry.source_name, entry.source_bytes);
+            }
+        }
+        Command::Audit {
+            manifest,
+            inventory,
+            output,
+        } => {
+            let manifest = read_historical_source_manifest(manifest)?;
+            let mut inventory = Inventory::open_read_only(inventory)?;
+            let work_units = inventory.work_units()?;
+            let fragment = ActiveRawFragment::export(
+                &mut inventory,
+                "historical-completion-audit",
+                "inventory://historical-campaign",
+            )?;
+            let active_work_unit_ids: BTreeSet<_> = fragment
+                .work_units()
+                .iter()
+                .map(|work| work.work_unit_id.clone())
+                .collect();
+            let audit = audit_historical_completion(
+                &manifest,
+                &work_units,
+                &active_work_unit_ids,
+                fragment.totals().objects,
+                fragment.totals().physical_rows,
+            )?;
+            if let Some(output) = output {
+                write_catalog_atomically(output, &audit)?;
+            }
+            println!(
+                concat!(
+                    "audit={} complete={} manifest_sources={} published_sources={} ",
+                    "objects={} rows={} duplicates={} rejected={} problems={}"
+                ),
+                audit.audit_id,
+                audit.is_complete(),
+                audit.totals().manifest_sources,
+                audit.totals().published_sources,
+                audit.totals().active_raw_objects,
+                audit.totals().active_raw_rows,
+                audit.totals().duplicate_events,
+                audit.totals().rejected_events,
+                audit.problems().len()
+            );
+            for problem in audit.problems() {
+                eprintln!("{}: {}", problem.source_name, problem.reason);
+            }
+            if !audit.is_complete() {
+                std::process::exit(2);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_manifest(manifest: &HistoricalSourceManifest) {
+    println!(
+        "manifest={} max_segment={} selection_high_water_gzip={} sources={} bytes={}",
+        manifest.manifest_id,
+        manifest.max_segment_number(),
+        manifest.selection_high_water_gzip(),
+        manifest.totals().sources,
+        manifest.totals().source_bytes
+    );
+}

--- a/crates/pensieve-lake/src/error.rs
+++ b/crates/pensieve-lake/src/error.rs
@@ -94,4 +94,8 @@ pub enum Error {
     /// A fragment or snapshot violates the catalog contract.
     #[error("invalid lake catalog: {0}")]
     InvalidCatalog(String),
+
+    /// A historical source manifest or its completion accounting is invalid.
+    #[error("invalid historical source manifest: {0}")]
+    InvalidSourceManifest(String),
 }

--- a/crates/pensieve-lake/src/inventory.rs
+++ b/crates/pensieve-lake/src/inventory.rs
@@ -470,6 +470,24 @@ impl Inventory {
             .map_err(Into::into)
     }
 
+    /// List every work unit in stable source-path and identity order.
+    pub fn work_units(&self) -> Result<Vec<WorkUnitRecord>> {
+        let mut statement = self.connection.prepare(
+            r#"
+            SELECT id, source_path, source_bytes, source_sha256,
+                   target_uncompressed_bytes, max_event_bytes, object_prefix,
+                   writer_version, state, input_events, output_rows,
+                   rejected_events, error
+            FROM work_units
+            ORDER BY source_path, id
+            "#,
+        )?;
+        let records = statement
+            .query_map([], work_unit_from_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(records)
+    }
+
     /// Transition a work unit, enforcing the durable state machine.
     pub fn transition_work(
         &mut self,

--- a/crates/pensieve-lake/src/lib.rs
+++ b/crates/pensieve-lake/src/lib.rs
@@ -8,6 +8,7 @@ mod catalog;
 mod error;
 mod inventory;
 mod publisher;
+mod source_manifest;
 mod work_unit;
 
 pub use catalog::{
@@ -21,6 +22,12 @@ pub use inventory::{
     WorkUnitRegistration,
 };
 pub use publisher::{LocalObjectStore, PublishedObject, Publisher, S3Publisher, S3PublisherConfig};
+pub use source_manifest::{
+    CompletionProblem, CompletionTotals, HISTORICAL_SOURCE_MANIFEST_FORMAT,
+    HistoricalCompletionAudit, HistoricalSourceEntry, HistoricalSourceManifest,
+    HistoricalSourceTotals, audit_historical_completion, read_historical_source_manifest,
+    write_historical_source_manifest_noclobber,
+};
 pub use work_unit::{
     CampaignConfig, CampaignSummary, CleanupSummary, DEFAULT_TARGET_UNCOMPRESSED_BYTES,
     cleanup_published_local_artifacts, run_notepack_work_unit, sha256_file,

--- a/crates/pensieve-lake/src/source_manifest.rs
+++ b/crates/pensieve-lake/src/source_manifest.rs
@@ -1,0 +1,721 @@
+//! Frozen historical-source manifests and completion accounting.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{Error, Result, WorkState, WorkUnitRecord};
+
+/// Format identifier for the historical notepack source manifest.
+pub const HISTORICAL_SOURCE_MANIFEST_FORMAT: &str = "pensieve.historical-source-manifest.v1";
+
+/// One exact source object selected for the bounded historical campaign.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct HistoricalSourceEntry {
+    /// Logical segment number parsed from the canonical filename.
+    pub segment_number: u64,
+    /// Exact source object name, without a host-local path.
+    pub source_name: String,
+    /// Exact remote object bytes observed when the manifest was frozen.
+    pub source_bytes: u64,
+}
+
+/// Aggregate source-manifest totals.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HistoricalSourceTotals {
+    /// Number of selected logical source segments.
+    pub sources: u64,
+    /// Sum of selected source-object bytes.
+    pub source_bytes: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct HistoricalSourcePayload {
+    format: String,
+    max_segment_number: u64,
+    selection_high_water_gzip: u64,
+    entries: Vec<HistoricalSourceEntry>,
+    totals: HistoricalSourceTotals,
+}
+
+/// Content-addressed, immutable input universe for one historical campaign.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HistoricalSourceManifest {
+    /// SHA-256 identity of the compact canonical payload.
+    pub manifest_id: String,
+    #[serde(flatten)]
+    payload: HistoricalSourcePayload,
+}
+
+#[derive(Debug, Deserialize)]
+struct RcloneLsJsonEntry {
+    #[serde(rename = "Path")]
+    path: String,
+    #[serde(rename = "Size")]
+    size: i64,
+    #[serde(rename = "IsDir", default)]
+    is_dir: bool,
+}
+
+#[derive(Default)]
+struct Representations {
+    plain: Option<HistoricalSourceEntry>,
+    gzip: Option<HistoricalSourceEntry>,
+}
+
+impl HistoricalSourceManifest {
+    /// Select a deterministic, bounded manifest from `rclone lsjson` output.
+    pub fn from_rclone_lsjson(bytes: &[u8], max_segment_number: u64) -> Result<Self> {
+        let remote_entries: Vec<RcloneLsJsonEntry> = serde_json::from_slice(bytes)?;
+        let mut representations = BTreeMap::<u64, Representations>::new();
+        let mut selection_high_water_gzip = None;
+
+        for remote in remote_entries {
+            if remote.is_dir {
+                continue;
+            }
+            let (segment_number, compressed) = parse_source_name(&remote.path)?;
+            let source_bytes = u64::try_from(remote.size).map_err(|_| {
+                Error::InvalidSourceManifest(format!(
+                    "source {} has a negative byte size",
+                    remote.path
+                ))
+            })?;
+            let entry = HistoricalSourceEntry {
+                segment_number,
+                source_name: remote.path,
+                source_bytes,
+            };
+            let representation = representations.entry(segment_number).or_default();
+            let slot = if compressed {
+                selection_high_water_gzip = Some(
+                    selection_high_water_gzip
+                        .map_or(segment_number, |current: u64| current.max(segment_number)),
+                );
+                &mut representation.gzip
+            } else {
+                &mut representation.plain
+            };
+            match slot {
+                Some(existing) if existing != &entry => {
+                    return Err(Error::InvalidSourceManifest(format!(
+                        "source representation conflicts with a duplicate listing: {}",
+                        entry.source_name
+                    )));
+                }
+                Some(_) => {}
+                None => *slot = Some(entry),
+            }
+        }
+
+        let selection_high_water_gzip = selection_high_water_gzip.ok_or_else(|| {
+            Error::InvalidSourceManifest(
+                "no sealed gzip segment exists to establish a source high-water mark".to_owned(),
+            )
+        })?;
+        if max_segment_number > selection_high_water_gzip {
+            return Err(Error::InvalidSourceManifest(format!(
+                "historical boundary {max_segment_number} is above the visible gzip high-water \
+                 mark {selection_high_water_gzip}"
+            )));
+        }
+        let mut entries = Vec::new();
+        for (segment_number, representation) in representations {
+            if segment_number > max_segment_number {
+                continue;
+            }
+            if let Some(gzip) = representation.gzip {
+                entries.push(gzip);
+            } else if segment_number < selection_high_water_gzip
+                && let Some(plain) = representation.plain
+            {
+                entries.push(plain);
+            }
+        }
+        if entries.is_empty() {
+            return Err(Error::InvalidSourceManifest(
+                "bounded source selection is empty".to_owned(),
+            ));
+        }
+
+        let payload = HistoricalSourcePayload {
+            format: HISTORICAL_SOURCE_MANIFEST_FORMAT.to_owned(),
+            max_segment_number,
+            selection_high_water_gzip,
+            totals: source_totals(&entries)?,
+            entries,
+        };
+        validate_payload(&payload)?;
+        Ok(Self {
+            manifest_id: content_id(&payload)?,
+            payload,
+        })
+    }
+
+    /// Inclusive historical segment boundary.
+    pub fn max_segment_number(&self) -> u64 {
+        self.payload.max_segment_number
+    }
+
+    /// Highest gzip segment visible when the manifest was frozen.
+    pub fn selection_high_water_gzip(&self) -> u64 {
+        self.payload.selection_high_water_gzip
+    }
+
+    /// Selected source objects in ascending segment-number order.
+    pub fn entries(&self) -> &[HistoricalSourceEntry] {
+        &self.payload.entries
+    }
+
+    /// Aggregate source totals.
+    pub fn totals(&self) -> &HistoricalSourceTotals {
+        &self.payload.totals
+    }
+
+    /// Verify structure, ordering, totals, boundary, and content identity.
+    pub fn validate(&self) -> Result<()> {
+        validate_payload(&self.payload)?;
+        let expected = content_id(&self.payload)?;
+        if self.manifest_id != expected {
+            return Err(Error::InvalidSourceManifest(format!(
+                "manifest identity mismatch: expected {expected}, found {}",
+                self.manifest_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// One completion-accounting defect.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct CompletionProblem {
+    /// Source filename or inventory identity involved.
+    pub source_name: String,
+    /// Operator-readable reason the completion gate is not satisfied.
+    pub reason: String,
+}
+
+/// Aggregate campaign completion accounting.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CompletionTotals {
+    /// Frozen source-manifest entries.
+    pub manifest_sources: u64,
+    /// Manifest entries with durably published work.
+    pub published_sources: u64,
+    /// Published canonical rows.
+    pub output_rows: u64,
+    /// Invalid source frames recorded by published work.
+    pub rejected_events: u64,
+    /// Valid duplicate source events inferred from input accounting.
+    pub duplicate_events: u64,
+    /// Active raw Parquet objects selected by the inventory.
+    pub active_raw_objects: u64,
+    /// Active raw Parquet physical rows.
+    pub active_raw_rows: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct CompletionPayload {
+    format: String,
+    manifest_id: String,
+    complete: bool,
+    totals: CompletionTotals,
+    problems: Vec<CompletionProblem>,
+}
+
+/// Deterministic completion report for one manifest and inventory snapshot.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HistoricalCompletionAudit {
+    /// SHA-256 identity of the compact canonical report payload.
+    pub audit_id: String,
+    #[serde(flatten)]
+    payload: CompletionPayload,
+}
+
+impl HistoricalCompletionAudit {
+    /// Whether the frozen manifest is completely and consistently published.
+    pub fn is_complete(&self) -> bool {
+        self.payload.complete
+    }
+
+    /// Aggregate campaign accounting.
+    pub fn totals(&self) -> &CompletionTotals {
+        &self.payload.totals
+    }
+
+    /// Defects preventing a complete result.
+    pub fn problems(&self) -> &[CompletionProblem] {
+        &self.payload.problems
+    }
+}
+
+/// Compare a frozen source universe with the complete inventory and active catalog view.
+pub fn audit_historical_completion(
+    manifest: &HistoricalSourceManifest,
+    work_units: &[WorkUnitRecord],
+    active_work_unit_ids: &BTreeSet<String>,
+    active_raw_objects: u64,
+    active_raw_rows: u64,
+) -> Result<HistoricalCompletionAudit> {
+    manifest.validate()?;
+    let manifest_names: BTreeSet<_> = manifest
+        .entries()
+        .iter()
+        .map(|entry| entry.source_name.as_str())
+        .collect();
+    let mut by_source = BTreeMap::<String, Vec<&WorkUnitRecord>>::new();
+    let mut problems = Vec::new();
+    for work in work_units {
+        let Some(source_name) = work
+            .source_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_owned)
+        else {
+            problems.push(CompletionProblem {
+                source_name: work.id.clone(),
+                reason: "inventory source path has no UTF-8 filename".to_owned(),
+            });
+            continue;
+        };
+        by_source.entry(source_name).or_default().push(work);
+    }
+
+    let mut totals = CompletionTotals {
+        manifest_sources: manifest.totals().sources,
+        active_raw_objects,
+        active_raw_rows,
+        ..CompletionTotals::default()
+    };
+    for entry in manifest.entries() {
+        let Some(records) = by_source.get(&entry.source_name) else {
+            problems.push(CompletionProblem {
+                source_name: entry.source_name.clone(),
+                reason: "source has no inventory work unit".to_owned(),
+            });
+            continue;
+        };
+        if records.len() != 1 {
+            problems.push(CompletionProblem {
+                source_name: entry.source_name.clone(),
+                reason: format!("source has {} inventory work units", records.len()),
+            });
+            continue;
+        }
+        let work = records[0];
+        if work.source_bytes != entry.source_bytes {
+            problems.push(CompletionProblem {
+                source_name: entry.source_name.clone(),
+                reason: format!(
+                    "source byte size differs: manifest={} inventory={}",
+                    entry.source_bytes, work.source_bytes
+                ),
+            });
+        }
+        if !matches!(
+            work.state,
+            WorkState::Published | WorkState::SourceCommitted
+        ) {
+            problems.push(CompletionProblem {
+                source_name: entry.source_name.clone(),
+                reason: format!("work unit is {}", work.state),
+            });
+            continue;
+        }
+        if !active_work_unit_ids.contains(&work.id) {
+            problems.push(CompletionProblem {
+                source_name: entry.source_name.clone(),
+                reason: "published work is absent from the active-raw catalog view".to_owned(),
+            });
+            continue;
+        }
+        let Some(accounted) = work.output_rows.checked_add(work.rejected_events) else {
+            return Err(Error::InvalidSourceManifest(format!(
+                "event accounting overflows for {}",
+                entry.source_name
+            )));
+        };
+        let Some(duplicate_events) = work.input_events.checked_sub(accounted) else {
+            problems.push(CompletionProblem {
+                source_name: entry.source_name.clone(),
+                reason: "output plus rejected events exceeds input events".to_owned(),
+            });
+            continue;
+        };
+        totals.published_sources = totals.published_sources.checked_add(1).ok_or_else(|| {
+            Error::InvalidSourceManifest("published source count overflows u64".to_owned())
+        })?;
+        totals.output_rows = totals
+            .output_rows
+            .checked_add(work.output_rows)
+            .ok_or_else(|| {
+                Error::InvalidSourceManifest("output row count overflows u64".to_owned())
+            })?;
+        totals.rejected_events = totals
+            .rejected_events
+            .checked_add(work.rejected_events)
+            .ok_or_else(|| {
+                Error::InvalidSourceManifest("rejected event count overflows u64".to_owned())
+            })?;
+        totals.duplicate_events = totals
+            .duplicate_events
+            .checked_add(duplicate_events)
+            .ok_or_else(|| {
+                Error::InvalidSourceManifest("duplicate event count overflows u64".to_owned())
+            })?;
+    }
+
+    for source_name in by_source.keys() {
+        if !manifest_names.contains(source_name.as_str()) {
+            problems.push(CompletionProblem {
+                source_name: source_name.clone(),
+                reason: "inventory work is outside the frozen historical manifest".to_owned(),
+            });
+        }
+    }
+    if totals.active_raw_rows != totals.output_rows {
+        problems.push(CompletionProblem {
+            source_name: "active-raw-catalog".to_owned(),
+            reason: format!(
+                "active raw row total differs from published output accounting: catalog={} \
+                 inventory={}",
+                totals.active_raw_rows, totals.output_rows
+            ),
+        });
+    }
+    problems.sort();
+    let complete = problems.is_empty() && totals.published_sources == manifest.totals().sources;
+    let payload = CompletionPayload {
+        format: "pensieve.historical-completion-audit.v1".to_owned(),
+        manifest_id: manifest.manifest_id.clone(),
+        complete,
+        totals,
+        problems,
+    };
+    Ok(HistoricalCompletionAudit {
+        audit_id: content_id(&payload)?,
+        payload,
+    })
+}
+
+/// Read and fully validate a canonical source manifest.
+pub fn read_historical_source_manifest(path: impl AsRef<Path>) -> Result<HistoricalSourceManifest> {
+    let bytes = fs::read(path)?;
+    let manifest: HistoricalSourceManifest = serde_json::from_slice(&bytes)?;
+    manifest.validate()?;
+    if bytes != canonical_json(&manifest)? {
+        return Err(Error::InvalidSourceManifest(
+            "source manifest JSON is not canonically encoded".to_owned(),
+        ));
+    }
+    Ok(manifest)
+}
+
+/// Create a canonical manifest file without replacing an existing freeze.
+pub fn write_historical_source_manifest_noclobber(
+    path: impl AsRef<Path>,
+    manifest: &HistoricalSourceManifest,
+) -> Result<()> {
+    manifest.validate()?;
+    let path = path.as_ref();
+    let parent = path.parent().filter(|path| !path.as_os_str().is_empty());
+    let parent = parent.unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    temporary.write_all(&canonical_json(manifest)?)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary.persist_noclobber(path).map_err(|error| {
+        if error.error.kind() == std::io::ErrorKind::AlreadyExists {
+            Error::InvalidSourceManifest(format!(
+                "refusing to replace frozen source manifest {}",
+                path.display()
+            ))
+        } else {
+            Error::Io(error.error)
+        }
+    })?;
+    File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn parse_source_name(name: &str) -> Result<(u64, bool)> {
+    if name.contains('/') || name.contains('\\') {
+        return Err(Error::InvalidSourceManifest(format!(
+            "source name is not a single path component: {name}"
+        )));
+    }
+    let Some(rest) = name.strip_prefix("segment-") else {
+        return Err(Error::InvalidSourceManifest(format!(
+            "unexpected source name: {name}"
+        )));
+    };
+    let (digits, compressed) = if let Some(digits) = rest.strip_suffix(".notepack.gz") {
+        (digits, true)
+    } else if let Some(digits) = rest.strip_suffix(".notepack") {
+        (digits, false)
+    } else {
+        return Err(Error::InvalidSourceManifest(format!(
+            "unexpected source name: {name}"
+        )));
+    };
+    if digits.len() != 9 || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(Error::InvalidSourceManifest(format!(
+            "source name does not use a nine-digit segment number: {name}"
+        )));
+    }
+    let segment_number = digits.parse::<u64>().map_err(|_| {
+        Error::InvalidSourceManifest(format!("invalid segment number in source name: {name}"))
+    })?;
+    Ok((segment_number, compressed))
+}
+
+fn validate_payload(payload: &HistoricalSourcePayload) -> Result<()> {
+    if payload.format != HISTORICAL_SOURCE_MANIFEST_FORMAT {
+        return Err(Error::InvalidSourceManifest(format!(
+            "unsupported source manifest format {}",
+            payload.format
+        )));
+    }
+    if payload.entries.is_empty() {
+        return Err(Error::InvalidSourceManifest(
+            "source manifest has no entries".to_owned(),
+        ));
+    }
+    if payload.max_segment_number > payload.selection_high_water_gzip {
+        return Err(Error::InvalidSourceManifest(format!(
+            "historical boundary {} is above the visible gzip high-water mark {}",
+            payload.max_segment_number, payload.selection_high_water_gzip
+        )));
+    }
+    let mut previous = None;
+    for entry in &payload.entries {
+        let (number, compressed) = parse_source_name(&entry.source_name)?;
+        if number != entry.segment_number {
+            return Err(Error::InvalidSourceManifest(format!(
+                "source {} has inconsistent segment number {}",
+                entry.source_name, entry.segment_number
+            )));
+        }
+        if number > payload.max_segment_number {
+            return Err(Error::InvalidSourceManifest(format!(
+                "source {} crosses historical boundary {}",
+                entry.source_name, payload.max_segment_number
+            )));
+        }
+        if !compressed && number >= payload.selection_high_water_gzip {
+            return Err(Error::InvalidSourceManifest(format!(
+                "plain source {} is not below the gzip high-water mark",
+                entry.source_name
+            )));
+        }
+        if previous.is_some_and(|previous| previous >= number) {
+            return Err(Error::InvalidSourceManifest(
+                "source entries are not strictly ordered by segment number".to_owned(),
+            ));
+        }
+        previous = Some(number);
+    }
+    if source_totals(&payload.entries)? != payload.totals {
+        return Err(Error::InvalidSourceManifest(
+            "source manifest totals do not match its entries".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn source_totals(entries: &[HistoricalSourceEntry]) -> Result<HistoricalSourceTotals> {
+    let sources = u64::try_from(entries.len()).map_err(|_| {
+        Error::InvalidSourceManifest("source count cannot be represented as u64".to_owned())
+    })?;
+    let source_bytes = entries.iter().try_fold(0_u64, |total, entry| {
+        total.checked_add(entry.source_bytes).ok_or_else(|| {
+            Error::InvalidSourceManifest("source byte total overflows u64".to_owned())
+        })
+    })?;
+    Ok(HistoricalSourceTotals {
+        sources,
+        source_bytes,
+    })
+}
+
+fn canonical_json(value: &impl Serialize) -> Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn content_id(value: &impl Serialize) -> Result<String> {
+    Ok(format!(
+        "sha256:{:x}",
+        Sha256::digest(serde_json::to_vec(value)?)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn lsjson(entries: &[(&str, i64)]) -> Vec<u8> {
+        let entries: Vec<_> = entries
+            .iter()
+            .map(|(path, size)| {
+                serde_json::json!({
+                    "Path": path,
+                    "Size": size,
+                    "IsDir": false
+                })
+            })
+            .collect();
+        serde_json::to_vec(&entries).expect("lsjson")
+    }
+
+    #[test]
+    fn selection_is_bounded_and_prefers_gzip() {
+        let manifest = HistoricalSourceManifest::from_rclone_lsjson(
+            &lsjson(&[
+                ("segment-000000000.notepack", 100),
+                ("segment-000000000.notepack.gz", 50),
+                ("segment-000000001.notepack", 101),
+                ("segment-000000002.notepack.gz", 52),
+                ("segment-000000003.notepack.gz", 53),
+            ]),
+            2,
+        )
+        .expect("manifest");
+
+        assert_eq!(manifest.max_segment_number(), 2);
+        assert_eq!(manifest.selection_high_water_gzip(), 3);
+        assert_eq!(
+            manifest
+                .entries()
+                .iter()
+                .map(|entry| entry.source_name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "segment-000000000.notepack.gz",
+                "segment-000000001.notepack",
+                "segment-000000002.notepack.gz"
+            ]
+        );
+        assert_eq!(manifest.totals().source_bytes, 203);
+    }
+
+    #[test]
+    fn gzip_representation_wins_at_high_water() {
+        let manifest = HistoricalSourceManifest::from_rclone_lsjson(
+            &lsjson(&[
+                ("segment-000000000.notepack.gz", 50),
+                ("segment-000000001.notepack", 101),
+                ("segment-000000001.notepack.gz", 51),
+            ]),
+            1,
+        )
+        .expect("manifest");
+        assert_eq!(manifest.entries().len(), 2);
+        assert_eq!(
+            manifest.entries()[1].source_name,
+            "segment-000000001.notepack.gz"
+        );
+    }
+
+    #[test]
+    fn boundary_cannot_exceed_visible_gzip_high_water() {
+        let error = HistoricalSourceManifest::from_rclone_lsjson(
+            &lsjson(&[("segment-000000000.notepack.gz", 50)]),
+            1,
+        )
+        .expect_err("unsafe boundary");
+        assert!(error.to_string().contains("above the visible gzip"));
+    }
+
+    #[test]
+    fn manifest_round_trip_requires_canonical_bytes_and_no_clobber() {
+        let manifest = HistoricalSourceManifest::from_rclone_lsjson(
+            &lsjson(&[("segment-000000000.notepack.gz", 50)]),
+            0,
+        )
+        .expect("manifest");
+        let directory = tempfile::tempdir().expect("directory");
+        let path = directory.path().join("manifest.json");
+        write_historical_source_manifest_noclobber(&path, &manifest).expect("write");
+        assert_eq!(
+            read_historical_source_manifest(&path).expect("read"),
+            manifest
+        );
+        let error =
+            write_historical_source_manifest_noclobber(&path, &manifest).expect_err("no clobber");
+        assert!(error.to_string().contains("refusing to replace"));
+    }
+
+    #[test]
+    fn audit_reports_missing_failed_and_unexpected_work() {
+        let manifest = HistoricalSourceManifest::from_rclone_lsjson(
+            &lsjson(&[
+                ("segment-000000000.notepack.gz", 50),
+                ("segment-000000001.notepack.gz", 51),
+            ]),
+            1,
+        )
+        .expect("manifest");
+        let published = work(
+            "work-published",
+            "segment-000000000.notepack.gz",
+            50,
+            WorkState::Published,
+        );
+        let unexpected = work(
+            "work-unexpected",
+            "segment-000000002.notepack.gz",
+            52,
+            WorkState::Failed,
+        );
+        let audit = audit_historical_completion(
+            &manifest,
+            &[published, unexpected],
+            &BTreeSet::from(["work-published".to_owned()]),
+            1,
+            2,
+        )
+        .expect("audit");
+
+        assert!(!audit.is_complete());
+        assert_eq!(audit.totals().published_sources, 1);
+        assert_eq!(audit.problems().len(), 2);
+        assert!(
+            audit
+                .problems()
+                .iter()
+                .any(|problem| problem.reason.contains("no inventory"))
+        );
+        assert!(
+            audit
+                .problems()
+                .iter()
+                .any(|problem| problem.reason.contains("outside"))
+        );
+    }
+
+    fn work(id: &str, source_name: &str, source_bytes: u64, state: WorkState) -> WorkUnitRecord {
+        WorkUnitRecord {
+            id: id.to_owned(),
+            source_path: PathBuf::from("/input").join(source_name),
+            source_bytes,
+            source_sha256: "11".repeat(32),
+            target_uncompressed_bytes: 1,
+            max_event_bytes: 1,
+            object_prefix: "nostr/v1".to_owned(),
+            writer_version: "test".to_owned(),
+            state,
+            input_events: 2,
+            output_rows: 2,
+            rejected_events: 0,
+            error: None,
+        }
+    }
+}

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -510,8 +510,20 @@ space and post-publication cleanup. Single-request uploads are sufficient for
 the present campaign; multipart upload and worker concurrency are deferred
 optimizations rather than migration prerequisites. Failed work remains in the
 journal and its source remains available for an idempotent retry. After the
-initial startup inventory completes, a catch-up pass must process any source
-segments that arrived after that inventory was captured.
+initial startup inventory completes, a catch-up pass must process the remaining
+sources from a frozen, content-addressed manifest whose inclusive segment
+boundary is exactly `H`. The worker must never keep extending that finite
+historical campaign merely because newer source objects appear remotely.
+
+Implementation checkpoint (2026-07-28): the campaign has a canonical source
+manifest built from one `rclone lsjson` capture. It records the selected source
+name and exact byte size for every segment through `H = 7702`, prefers gzip
+when both representations exist, excludes an unsafe plain high-water file, and
+is created with no-clobber semantics. Every later pass verifies the configured
+boundary and consumes that same manifest. A deterministic completion audit
+joins the frozen source universe to the complete campaign inventory and active
+raw catalog view, then reports missing, failed, in-progress, unexpected, and
+event-accounting defects.
 
 #### P2d — Converge and verify
 
@@ -523,14 +535,22 @@ segments that arrived after that inventory was captured.
       state is excluded. Conflicts fail closed, and snapshots explicitly state
       that raw rows are not event-ID-deduplicated. See
       `docs/lake_active_file_catalog.md`.
-- [ ] Verify every historical work unit against its sealed notepack input and
-      periodically create a coordinated go-forward checkpoint by closing the
+- [ ] Complete the frozen historical-source manifest through `H`: every entry
+      must have one published inventory work unit, valid input/output/reject/
+      duplicate accounting, and active objects that pass strict checksum and
+      V1 validation. Repair or explicitly quarantine every reported exception.
+- [ ] Perform full seven-field source-to-Parquet comparison for every anomaly,
+      repaired or salvaged input, historical/live boundary input, and a
+      deterministic sample of ordinary historical work. A second exhaustive
+      1.4-billion-event body comparison is not a migration prerequisite: the
+      converter already verifies every source event ID/signature and the strict
+      validator independently reopens every output row and verifies all seven
+      logical fields.
+- [ ] Periodically create a coordinated go-forward checkpoint by closing the
       current live batch and sealing the current notepack segment at the same
-      ingest barrier. Compare ID-keyed seven-field values through that barrier,
-      not file counts or physical row counts.
-- [ ] Verify the active union of historical and live raw objects against the
-      notepack archive through `H` plus the sustained go-forward stream. The
-      intentional overlap at `H` must disappear under ID-keyed comparison.
+      ingest barrier. Compare complete ID-keyed seven-field values through that
+      barrier. The intentional historical/live overlap at `H` must disappear
+      under ID-keyed comparison.
 - [ ] If a go-forward mismatch is found, replay the corresponding post-`H`
       notepack range through the shared repair/import path, publish the repair
       as active raw objects, and repeat parity verification. Do not hide a gap
@@ -549,10 +569,12 @@ physical rows, and 102,813,011,702 object bytes. This is a reproducible
 checkpoint while both ingestion paths continue, not the still-pending
 historical/live parity proof.
 
-**Gate:** all sealed notepack inputs through `H` and N sustained go-forward
-windows have complete ID-keyed parity; every active output passes the
-independent V1 validator; crash recovery converges at every publication
-transition; and the proposed P5 unsealed-event RPO is demonstrated.
+**Gate:** the frozen manifest accounts for every sealed notepack input through
+`H`; all active output passes the independent V1 validator; anomaly, repair,
+boundary, and deterministic-sample content comparisons pass; N sustained
+go-forward windows have complete ID-keyed parity; crash recovery converges at
+every publication transition; and the proposed P5 unsealed-event RPO is
+demonstrated.
 
 **Rollback:** stop live Parquet sealing and historical conversion. Parquet is
 shadow-only; authoritative notepack ingestion is unaffected.
@@ -738,7 +760,7 @@ The diff harness (seeded in P0) is what makes cutovers trustworthy:
 
 ## 9. Status tracker
 
-Updated 2026-07-27.
+Updated 2026-07-28.
 
 - **P0 Foundation** — in progress (disk relief, archive-format acceptance,
   durable production object storage, real Hetzner compatibility and
@@ -754,15 +776,19 @@ Updated 2026-07-27.
   deterministic unified active-raw snapshot catalog are implemented. The live
   replay floor is segment 7703, establishing the historical boundary at
   `H = 7702`. The sequential historical campaign is active on its dedicated VM;
-  transient upload failures remain safely retryable. Segment 7703 was sealed as
-  an empty gzip after a now-fixed seal/compression race. Its exact 21,972 event
-  IDs were preserved from RocksDB; exhaustive relay recovery found 4,833 valid
-  unique event bodies and left 17,139 IDs as an explicit known gap. The repair
-  was validated, published as a separate immutable Parquet work unit, restored
-  to ClickHouse, and included with the historical and live inventories in the
-  first operational unified snapshot. Campaign completion/catch-up, full
-  ID-keyed historical/live parity, coordinated go-forward windows, publication
-  fault coverage, and the post-P5 unsealed-buffer failure-domain proof remain.
+  transient upload failures remain safely retryable. The finite catch-up source
+  universe is now frozen at `H` and has deterministic completion accounting.
+  Segment 7703 was sealed as an empty gzip after a now-fixed seal/compression
+  race. Its exact 21,972 event IDs were preserved from RocksDB; initial
+  exact-ID relay recovery found 4,833 valid unique event bodies, with 17,139
+  IDs currently unrecovered and eligible for recurring wider-relay attempts.
+  The repair was validated, published as a separate immutable Parquet work
+  unit, restored to ClickHouse, and included with the historical and live
+  inventories in the first operational unified snapshot. Campaign
+  completion/catch-up, explicit handling of damaged historical inputs,
+  targeted historical content comparison, coordinated go-forward parity
+  windows, publication fault coverage, and the post-P5 unsealed-buffer
+  failure-domain proof remain.
 - **P3 Optimization + new analytics** — not started
 - **P4 Reader cutover** — not started
 - **P5 Parquet durability authority** — not started

--- a/justfile
+++ b/justfile
@@ -49,6 +49,10 @@ parquet-interop:
 parquet-campaign *ARGS:
     cargo run -p pensieve-lake --bin pensieve-parquet-campaign -- {{ARGS}}
 
+# Freeze, inspect, or audit a bounded historical-source manifest.
+source-manifest *ARGS:
+    cargo run -p pensieve-lake --bin pensieve-source-manifest -- {{ARGS}}
+
 # Export, merge, or verify deterministic active-file lake catalogs.
 lake-catalog *ARGS:
     cargo run -p pensieve-lake --bin pensieve-lake-catalog -- {{ARGS}}

--- a/ops/RUNBOOK.md
+++ b/ops/RUNBOOK.md
@@ -113,6 +113,66 @@ the optional shadow is disabled. Treat that as a failed shadow deployment:
 correct the configuration deliberately; do not delete a populated inventory
 merely to bypass the guard.
 
+## Bounded historical Parquet catch-up
+
+The historical campaign is finite. Its immutable input universe ends at the
+inclusive historical/live boundary `H = 7702`; later live segments belong to
+the live shadow. Do not restart a healthy campaign merely to deploy the source
+manifest support. Install it for the next pass after the current sequential
+pass has stopped normally.
+
+1. Pull the merged revision and build both campaign binaries:
+   ```bash
+   cd /home/pensieve/pensieve
+   git pull --ff-only origin master
+   cargo build --release -p pensieve-lake \
+     --bin pensieve-parquet-campaign \
+     --bin pensieve-source-manifest
+   ```
+2. Set these non-secret values in the campaign environment:
+   ```bash
+   HISTORICAL_MAX_SEGMENT=7702
+   SOURCE_MANIFEST=/var/lib/pensieve-parquet/state/historical-source-manifest.json
+   SOURCE_MANIFEST_BIN=/home/pensieve/pensieve/target/release/pensieve-source-manifest
+   ```
+3. Freeze and inspect the manifest without downloading or publishing:
+   ```bash
+   sudo systemctl stop pensieve-parquet-campaign
+   sudo systemd-run --wait --pipe --collect \
+     --unit=pensieve-parquet-manifest-freeze \
+     --uid=pensieve --gid=pensieve \
+     --working-directory=/home/pensieve/pensieve \
+     --property=EnvironmentFile=/etc/pensieve/parquet-object-storage.env \
+     --property=EnvironmentFile=/etc/pensieve/parquet-campaign.env \
+     --setenv=INVENTORY_ONLY=1 \
+     /home/pensieve/pensieve/ops/scripts/run-parquet-archive-campaign.sh
+   sudo -u pensieve /home/pensieve/pensieve/target/release/pensieve-source-manifest \
+     verify \
+     --manifest /var/lib/pensieve-parquet/state/historical-source-manifest.json \
+     --expected-max-segment-number 7702
+   ```
+   The build is no-clobber. If the file already exists, the wrapper verifies
+   and reuses it. Never delete or replace a populated manifest to make a
+   boundary mismatch disappear; investigate the configuration instead.
+4. Start the bounded catch-up and let normal inventory idempotency skip sources
+   already published:
+   ```bash
+   sudo systemctl start pensieve-parquet-campaign
+   journalctl -u pensieve-parquet-campaign -f
+   ```
+5. After the pass is idle, write the content-addressed completion report:
+   ```bash
+   sudo -u pensieve /home/pensieve/pensieve/target/release/pensieve-source-manifest \
+     audit \
+     --manifest /var/lib/pensieve-parquet/state/historical-source-manifest.json \
+     --inventory /var/lib/pensieve-parquet/state/campaign.sqlite \
+     --output /var/lib/pensieve-parquet/state/historical-completion-audit.json
+   ```
+   Exit status `0` means the manifest, complete inventory, and active-raw view
+   reconcile. Exit status `2` means the report is valid but incomplete; repair
+   every named retryable failure or damaged-source exception rather than
+   editing the report or an existing Parquet object.
+
 ## One-time cutover (ops/ move + secrets → /etc)
 
 The move of compose/systemd paths and secrets to `/etc` must happen in lockstep with

--- a/ops/parquet-campaign.env.example
+++ b/ops/parquet-campaign.env.example
@@ -9,6 +9,13 @@ INPUT_DIR=/var/lib/pensieve-parquet/input
 RECEIPT_DIR=/var/lib/pensieve-parquet/state/receipts
 LOCK_FILE=/var/lib/pensieve-parquet/state/campaign.lock
 CAMPAIGN_BIN=/home/pensieve/pensieve/target/release/pensieve-parquet-campaign
+SOURCE_MANIFEST_BIN=/home/pensieve/pensieve/target/release/pensieve-source-manifest
+
+# Freeze this campaign to the inclusive historical/live boundary. The first
+# pass creates the manifest without overwriting an existing one; later passes
+# verify that this configured boundary still matches it.
+HISTORICAL_MAX_SEGMENT=7702
+SOURCE_MANIFEST=/var/lib/pensieve-parquet/state/historical-source-manifest.json
 
 # Preserve 5 GiB after reserving three times the compressed source bytes for
 # the current input, generated Parquet, and temporary files.

--- a/ops/scripts/run-parquet-archive-campaign.sh
+++ b/ops/scripts/run-parquet-archive-campaign.sh
@@ -80,16 +80,20 @@ INPUT_DIR="${INPUT_DIR:-/var/lib/pensieve-parquet/input}"
 RECEIPT_DIR="${RECEIPT_DIR:-/var/lib/pensieve-parquet/state/receipts}"
 LOCK_FILE="${LOCK_FILE:-/var/lib/pensieve-parquet/state/campaign.lock}"
 CAMPAIGN_BIN="${CAMPAIGN_BIN:-/home/pensieve/pensieve/target/release/pensieve-parquet-campaign}"
+SOURCE_MANIFEST_BIN="${SOURCE_MANIFEST_BIN:-/home/pensieve/pensieve/target/release/pensieve-source-manifest}"
+SOURCE_MANIFEST="${SOURCE_MANIFEST:-/var/lib/pensieve-parquet/state/historical-source-manifest.json}"
+HISTORICAL_MAX_SEGMENT="${HISTORICAL_MAX_SEGMENT:-}"
 MIN_FREE_BYTES="${MIN_FREE_BYTES:-5368709120}"
 WORKING_SPACE_MULTIPLIER="${WORKING_SPACE_MULTIPLIER:-3}"
 MAX_WORK_UNITS="${MAX_WORK_UNITS:-0}"
 INVENTORY_ONLY="${INVENTORY_ONLY:-0}"
 
 for name in SOURCE_REMOTE AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION \
-    S3_BUCKET S3_ENDPOINT_URL S3_ARCHIVE_PREFIX; do
+    S3_BUCKET S3_ENDPOINT_URL S3_ARCHIVE_PREFIX HISTORICAL_MAX_SEGMENT; do
     require_env "$name"
 done
-for name in MIN_FREE_BYTES WORKING_SPACE_MULTIPLIER MAX_WORK_UNITS INVENTORY_ONLY; do
+for name in HISTORICAL_MAX_SEGMENT MIN_FREE_BYTES WORKING_SPACE_MULTIPLIER \
+    MAX_WORK_UNITS INVENTORY_ONLY; do
     require_uint "$name"
 done
 if [ "$WORKING_SPACE_MULTIPLIER" -lt 2 ]; then
@@ -104,90 +108,42 @@ if [ ! -x "$CAMPAIGN_BIN" ]; then
     echo "Campaign binary is not executable: $CAMPAIGN_BIN" >&2
     exit 2
 fi
+if [ ! -x "$SOURCE_MANIFEST_BIN" ]; then
+    echo "Source manifest binary is not executable: $SOURCE_MANIFEST_BIN" >&2
+    exit 2
+fi
 
-install -d -m 0750 "$INPUT_DIR" "$STAGING_DIR" "$RECEIPT_DIR" "$(dirname "$LOCK_FILE")"
+install -d -m 0750 "$INPUT_DIR" "$STAGING_DIR" "$RECEIPT_DIR" \
+    "$(dirname "$LOCK_FILE")" "$(dirname "$SOURCE_MANIFEST")"
 exec 9>"$LOCK_FILE"
 if ! flock -n 9; then
     echo "Another Parquet archive campaign holds $LOCK_FILE" >&2
     exit 3
 fi
 
-source_inventory_raw="$(mktemp "$RECEIPT_DIR/.source-inventory-raw.XXXXXX")"
 source_inventory="$(mktemp "$RECEIPT_DIR/.source-inventory.XXXXXX")"
-source_inventory_meta="$(mktemp "$RECEIPT_DIR/.source-inventory-meta.XXXXXX")"
-trap 'rm -f "$source_inventory_raw" "$source_inventory" "$source_inventory_meta"' EXIT
-rclone lsf "$SOURCE_REMOTE" \
-    --files-only \
-    --max-depth 1 \
-    --include 'segment-*.notepack' \
-    --include 'segment-*.notepack.gz' >"$source_inventory_raw"
+trap 'rm -f "$source_inventory"' EXIT
 
-# The legacy archive may contain both the plain and gzip representation of the
-# same sealed segment. Prefer gzip and never process both. A plain-only segment
-# is eligible only below the highest gzip segment number: the plain file at or
-# above that high-water mark may still be the live, unsealed segment.
-if ! awk -v metadata="$source_inventory_meta" '
-    function segment_number(name, value) {
-        value = name
-        sub(/^segment-/, "", value)
-        sub(/[.]notepack([.]gz)?$/, "", value)
-        return value + 0
-    }
-
-    /^segment-[0-9]+[.]notepack[.]gz$/ {
-        base = $0
-        sub(/[.]gz$/, "", base)
-        gzip_by_base[base] = $0
-        number = segment_number($0)
-        if (!have_gzip || number > max_gzip) {
-            max_gzip = number
-        }
-        have_gzip = 1
-        next
-    }
-
-    /^segment-[0-9]+[.]notepack$/ {
-        plain[$0] = 1
-        next
-    }
-
-    {
-        print "Skipping unexpected source name: " $0 > "/dev/stderr"
-    }
-
-    END {
-        if (!have_gzip) {
-            print "No sealed gzip segments found; refusing to infer a safe source high-water mark" > "/dev/stderr"
-            exit 42
-        }
-
-        selected = 0
-        paired = 0
-        skipped_high_water = 0
-        for (base in gzip_by_base) {
-            print gzip_by_base[base]
-            selected++
-        }
-        for (name in plain) {
-            if (name in gzip_by_base) {
-                paired++
-            } else if (segment_number(name) < max_gzip) {
-                print name
-                selected++
-            } else {
-                skipped_high_water++
-            }
-        }
-        print max_gzip, selected, paired, skipped_high_water > metadata
-        close(metadata)
-    }
-' "$source_inventory_raw" >"$source_inventory"; then
-    echo "Unable to select a safe sealed source inventory" >&2
-    exit 4
+if [ ! -e "$SOURCE_MANIFEST" ]; then
+    source_inventory_json="$(mktemp "$RECEIPT_DIR/.source-inventory.XXXXXX.json")"
+    trap 'rm -f "$source_inventory" "${source_inventory_json:-}"' EXIT
+    rclone lsjson "$SOURCE_REMOTE" \
+        --files-only \
+        --max-depth 1 \
+        --include 'segment-*.notepack' \
+        --include 'segment-*.notepack.gz' >"$source_inventory_json"
+    "$SOURCE_MANIFEST_BIN" build \
+        --rclone-lsjson "$source_inventory_json" \
+        --max-segment-number "$HISTORICAL_MAX_SEGMENT" \
+        --output "$SOURCE_MANIFEST"
+    rm -f "$source_inventory_json"
 fi
-sort -V -o "$source_inventory" "$source_inventory"
-read -r max_sealed_gzip selected_sources paired_sources skipped_high_water <"$source_inventory_meta"
-echo "Source inventory: selected=$selected_sources max_sealed_gzip=$max_sealed_gzip paired_plain_skipped=$paired_sources high_water_plain_skipped=$skipped_high_water"
+
+"$SOURCE_MANIFEST_BIN" verify \
+    --manifest "$SOURCE_MANIFEST" \
+    --expected-max-segment-number "$HISTORICAL_MAX_SEGMENT"
+"$SOURCE_MANIFEST_BIN" entries \
+    --manifest "$SOURCE_MANIFEST" >"$source_inventory"
 if [ "$INVENTORY_ONLY" -eq 1 ]; then
     exit 0
 fi
@@ -195,11 +151,15 @@ fi
 attempted=0
 published=0
 failures=0
-while IFS= read -r filename; do
+while IFS=$'\t' read -r filename remote_bytes; do
     [ -n "$filename" ] || continue
     if ! [[ "$filename" =~ ^segment-[0-9]+\.notepack(\.gz)?$ ]]; then
         echo "Skipping unexpected source name: $filename" >&2
         continue
+    fi
+    if ! [[ "$remote_bytes" =~ ^[0-9]+$ ]]; then
+        echo "Manifest has invalid source size: $filename bytes=$remote_bytes" >&2
+        exit 4
     fi
 
     local_input="$INPUT_DIR/$filename"
@@ -212,11 +172,6 @@ while IFS= read -r filename; do
     fi
 
     remote_source="$SOURCE_REMOTE/$filename"
-    remote_bytes="$(rclone size --json "$remote_source" | jq -r '.bytes')"
-    if ! [[ "$remote_bytes" =~ ^[0-9]+$ ]]; then
-        echo "Unable to determine nonnegative source size: $remote_source" >&2
-        exit 4
-    fi
     available_bytes="$(df --output=avail -B1 "$INPUT_DIR" | tail -n 1 | tr -d ' ')"
     required_bytes=$((MIN_FREE_BYTES + remote_bytes * WORKING_SPACE_MULTIPLIER))
     if [ "$available_bytes" -lt "$required_bytes" ]; then


### PR DESCRIPTION
## Summary

- freeze the finite historical notepack source universe at H = 7702 in an immutable, content-addressed manifest
- make every catch-up pass consume and verify that manifest instead of re-listing a moving remote
- add deterministic campaign completion accounting against the full inventory and active-raw catalog view
- narrow the historical validation gate to exhaustive coverage/accounting plus targeted seven-field comparisons

## Operational safety

The currently running campaign is unchanged. The new wrapper is intended for the next catch-up pass after the existing sequential pass exits. A Linux inventory-only smoke test on the conversion VM produced 7,694 bounded sources through segment 7702 and left the active service running.

## Validation

- `just precommit`
- `bash -n ops/scripts/run-parquet-archive-campaign.sh`
- real Storage Box `rclone lsjson` manifest build and verification
- completion audit against a consistent SQLite backup of the live campaign journal
- isolated Linux wrapper inventory-only smoke test on the conversion VM