### PR TITLE
Add evidence-preserving archive recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,6 +3087,7 @@ dependencies = [
  "crossbeam-channel",
  "ctrlc",
  "flate2",
+ "futures-util",
  "hex",
  "metrics",
  "nostr-sdk",
@@ -3143,7 +3144,9 @@ dependencies = [
  "nostr",
  "notepack",
  "parquet",
+ "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.17",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ aws-sdk-s3 = "1.82"
 
 # Concurrency
 crossbeam-channel = "0.5"
+futures-util = "0.3"
 parking_lot = "0.12"
 num_cpus = "1.16"
 

--- a/crates/pensieve-ingest/Cargo.toml
+++ b/crates/pensieve-ingest/Cargo.toml
@@ -32,6 +32,10 @@ path = "src/bin/repair-dedupe.rs"
 name = "relay-cleanup"
 path = "src/bin/relay-cleanup.rs"
 
+[[bin]]
+name = "recover-events"
+path = "src/bin/recover-events.rs"
+
 [dependencies]
 # Internal crates
 pensieve-core = { path = "../pensieve-core" }
@@ -69,6 +73,7 @@ aws-sdk-s3.workspace = true
 
 # Concurrency
 crossbeam-channel.workspace = true
+futures-util.workspace = true
 parking_lot.workspace = true
 num_cpus.workspace = true
 
@@ -83,6 +88,7 @@ metrics.workspace = true
 # Error handling
 anyhow.workspace = true
 thiserror.workspace = true
+tempfile = "3.23"
 
 # CLI
 clap = { version = "4.4", features = ["derive", "env"] }
@@ -92,6 +98,3 @@ ctrlc.workspace = true
 
 # TLS (for rustls crypto provider)
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-
-[dev-dependencies]
-tempfile = "3.23"

--- a/crates/pensieve-ingest/src/bin/recover-events.rs
+++ b/crates/pensieve-ingest/src/bin/recover-events.rs
@@ -1,0 +1,379 @@
+//! Resumably recover exact Nostr event IDs from an operator-supplied relay set.
+
+use std::collections::HashSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use futures_util::{StreamExt, stream};
+use nostr_sdk::prelude::{Client, Event, EventId, Filter, JsonUtil};
+
+#[derive(Debug, Parser)]
+#[command(about = "Resumably recover exact Nostr event IDs from public relays")]
+struct Args {
+    /// One 64-character event ID per line.
+    ids: PathBuf,
+    /// Append-only validated recovered-event JSONL.
+    output_jsonl: PathBuf,
+    /// Atomically replaced snapshot of IDs not present in the output.
+    missing_ids: PathBuf,
+    /// Relay URLs, one per line; blank lines and # comments are ignored.
+    #[arg(long)]
+    relay_file: PathBuf,
+    /// Append-only operator journal for batch outcomes.
+    #[arg(long)]
+    journal: Option<PathBuf>,
+    /// Progressively smaller exact-ID request sizes.
+    #[arg(long, value_delimiter = ',', default_value = "100,20,1")]
+    batch_sizes: Vec<usize>,
+    /// Parallel relay-pool requests.
+    #[arg(long, default_value_t = 4)]
+    concurrency: usize,
+    /// Timeout for one batch request.
+    #[arg(long, default_value_t = 12)]
+    request_timeout_secs: u64,
+    /// Relay connection warm-up before requests begin.
+    #[arg(long, default_value_t = 5)]
+    connect_wait_secs: u64,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("event recovery failed: {error:#}");
+        std::process::exit(1);
+    }
+}
+
+#[tokio::main]
+async fn run() -> Result<()> {
+    let args = Args::parse();
+    if args.concurrency == 0 {
+        bail!("--concurrency must be greater than zero");
+    }
+    if args.batch_sizes.is_empty() || args.batch_sizes.contains(&0) {
+        bail!("--batch-sizes must contain only positive values");
+    }
+    let ids = read_ids(&args.ids)?;
+    let target_ids: HashSet<_> = ids.iter().copied().collect();
+    let mut recovered = read_recovered(&args.output_jsonl, &target_ids)?;
+    let relays = read_relays(&args.relay_file)?;
+    eprintln!(
+        "targets={} already_recovered={} relays={}",
+        ids.len(),
+        recovered.len(),
+        relays.len()
+    );
+
+    let mut clients = Vec::with_capacity(args.concurrency);
+    for worker in 0..args.concurrency {
+        let client = Client::default();
+        let mut added = 0usize;
+        for relay in &relays {
+            match client.add_relay(relay).await {
+                Ok(true) => added += 1,
+                Ok(false) => {}
+                Err(error) => {
+                    eprintln!("worker={worker} failed_relay={relay} error={error}");
+                }
+            }
+        }
+        if added == 0 {
+            bail!("worker {worker} could not add any configured relay");
+        }
+        client.connect().await;
+        clients.push(client);
+    }
+    tokio::time::sleep(Duration::from_secs(args.connect_wait_secs)).await;
+
+    let output = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&args.output_jsonl)
+        .with_context(|| format!("failed to open {}", args.output_jsonl.display()))?;
+    let mut writer = BufWriter::new(output);
+    let mut journal = args
+        .journal
+        .as_ref()
+        .map(|path| {
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .with_context(|| format!("failed to open {}", path.display()))
+                .map(BufWriter::new)
+        })
+        .transpose()?;
+
+    for (pass_index, batch_size) in args.batch_sizes.iter().copied().enumerate() {
+        let missing: Vec<_> = ids
+            .iter()
+            .copied()
+            .filter(|id| !recovered.contains(id))
+            .collect();
+        if missing.is_empty() {
+            break;
+        }
+        let batches: Vec<_> = missing.chunks(batch_size).map(<[_]>::to_vec).collect();
+        let batch_count = batches.len();
+        eprintln!(
+            "pass={} batch_size={} missing={} batches={}",
+            pass_index + 1,
+            batch_size,
+            missing.len(),
+            batch_count
+        );
+
+        let requests = stream::iter(batches.into_iter().enumerate().map(|(batch_index, batch)| {
+            let client = clients[batch_index % clients.len()].clone();
+            let timeout = Duration::from_secs(args.request_timeout_secs);
+            async move {
+                let filter = Filter::new().ids(batch);
+                (batch_index, client.fetch_events(filter, timeout).await)
+            }
+        }))
+        .buffer_unordered(args.concurrency);
+        tokio::pin!(requests);
+        let mut completed = 0usize;
+        while let Some((batch_index, result)) = requests.next().await {
+            let mut added = 0usize;
+            match result {
+                Ok(events) => {
+                    for event in events {
+                        if !target_ids.contains(&event.id) || recovered.contains(&event.id) {
+                            continue;
+                        }
+                        event.verify().with_context(|| {
+                            format!("relay returned invalid event {}", event.id)
+                        })?;
+                        writeln!(writer, "{}", event.as_json())?;
+                        recovered.insert(event.id);
+                        added += 1;
+                    }
+                    if added > 0 {
+                        writer.flush()?;
+                        writer.get_ref().sync_data()?;
+                    }
+                    write_journal(
+                        journal.as_mut(),
+                        pass_index + 1,
+                        batch_index + 1,
+                        "ok",
+                        added,
+                        None,
+                    )?;
+                }
+                Err(error) => {
+                    eprintln!(
+                        "fetch_error pass={} batch={} error={error}",
+                        pass_index + 1,
+                        batch_index + 1
+                    );
+                    write_journal(
+                        journal.as_mut(),
+                        pass_index + 1,
+                        batch_index + 1,
+                        "error",
+                        0,
+                        Some(&error.to_string()),
+                    )?;
+                }
+            }
+            completed += 1;
+            if completed.is_multiple_of(10) || completed == batch_count {
+                eprintln!(
+                    "progress pass={} batches={}/{} recovered={}/{}",
+                    pass_index + 1,
+                    completed,
+                    batch_count,
+                    recovered.len(),
+                    ids.len()
+                );
+            }
+        }
+    }
+    writer.flush()?;
+    writer.get_ref().sync_data()?;
+    if let Some(journal) = journal.as_mut() {
+        journal.flush()?;
+        journal.get_ref().sync_data()?;
+    }
+    let missing = write_missing_atomically(&args.missing_ids, &ids, &recovered)?;
+    eprintln!(
+        "complete targets={} recovered={} missing={}",
+        ids.len(),
+        recovered.len(),
+        missing
+    );
+    Ok(())
+}
+
+fn read_ids(path: &Path) -> Result<Vec<EventId>> {
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut ids = Vec::new();
+    let mut unique = HashSet::new();
+    for (index, line) in BufReader::new(file).lines().enumerate() {
+        let value = line.with_context(|| format!("failed to read line {}", index + 1))?;
+        let id = EventId::from_hex(&value)
+            .with_context(|| format!("invalid event ID on line {}", index + 1))?;
+        if !unique.insert(id) {
+            bail!("duplicate event ID on line {}", index + 1);
+        }
+        ids.push(id);
+    }
+    if ids.is_empty() {
+        bail!("target ID file is empty");
+    }
+    Ok(ids)
+}
+
+fn read_relays(path: &Path) -> Result<Vec<String>> {
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut relays = Vec::new();
+    let mut unique = HashSet::new();
+    for line in BufReader::new(file).lines() {
+        let line = line?;
+        let value = line.split('#').next().unwrap_or_default().trim();
+        if !value.is_empty() && unique.insert(value.to_owned()) {
+            relays.push(value.to_owned());
+        }
+    }
+    if relays.is_empty() {
+        bail!("relay file has no relay URLs");
+    }
+    Ok(relays)
+}
+
+fn read_recovered(path: &Path, target_ids: &HashSet<EventId>) -> Result<HashSet<EventId>> {
+    if !path.exists() {
+        return Ok(HashSet::new());
+    }
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut recovered = HashSet::new();
+    for (index, line) in BufReader::new(file).lines().enumerate() {
+        let json = line.with_context(|| format!("failed to read output line {}", index + 1))?;
+        let event = Event::from_json(json)
+            .with_context(|| format!("invalid output event on line {}", index + 1))?;
+        event
+            .verify()
+            .with_context(|| format!("invalid output signature on line {}", index + 1))?;
+        if !target_ids.contains(&event.id) {
+            bail!("output contains non-target event {}", event.id);
+        }
+        if !recovered.insert(event.id) {
+            bail!("output contains duplicate event {}", event.id);
+        }
+    }
+    Ok(recovered)
+}
+
+fn write_missing_atomically(
+    path: &Path,
+    ids: &[EventId],
+    recovered: &HashSet<EventId>,
+) -> Result<usize> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    let mut missing = 0usize;
+    for id in ids {
+        if !recovered.contains(id) {
+            writeln!(temporary, "{id}")?;
+            missing += 1;
+        }
+    }
+    temporary.flush()?;
+    temporary.as_file_mut().sync_all()?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to publish {}", path.display()))?;
+    File::open(parent)?.sync_all()?;
+    Ok(missing)
+}
+
+fn write_journal(
+    journal: Option<&mut BufWriter<File>>,
+    pass: usize,
+    batch: usize,
+    result: &str,
+    recovered: usize,
+    error: Option<&str>,
+) -> Result<()> {
+    let Some(journal) = journal else {
+        return Ok(());
+    };
+    let entry = serde_json::json!({
+        "pass": pass,
+        "batch": batch,
+        "result": result,
+        "recovered": recovered,
+        "error": error,
+    });
+    writeln!(journal, "{entry}")?;
+    journal.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr_sdk::prelude::{EventBuilder, Keys, Kind};
+
+    use super::*;
+
+    fn event(content: &str) -> Event {
+        let keys = Keys::parse("0000000000000000000000000000000000000000000000000000000000000001")
+            .expect("keys");
+        EventBuilder::new(Kind::TextNote, content)
+            .sign_with_keys(&keys)
+            .expect("event")
+    }
+
+    #[test]
+    fn duplicate_target_ids_are_rejected() {
+        let directory = tempfile::tempdir().expect("directory");
+        let path = directory.path().join("ids.hex");
+        let id = event("one").id;
+        fs::write(&path, format!("{id}\n{id}\n")).expect("write IDs");
+        assert!(
+            read_ids(&path)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate")
+        );
+    }
+
+    #[test]
+    fn recovered_output_must_be_unique_and_in_target_set() {
+        let directory = tempfile::tempdir().expect("directory");
+        let output = directory.path().join("events.jsonl");
+        let target = event("target");
+        let other = event("other");
+        fs::write(&output, format!("{}\n", other.as_json())).expect("output");
+        let error = read_recovered(&output, &HashSet::from([target.id])).expect_err("non-target");
+        assert!(error.to_string().contains("non-target"));
+    }
+
+    #[test]
+    fn missing_snapshot_preserves_target_order_and_replaces_old_state() {
+        let directory = tempfile::tempdir().expect("directory");
+        let path = directory.path().join("missing.hex");
+        let first = event("first").id;
+        let second = event("second").id;
+        let third = event("third").id;
+        fs::write(&path, "stale\n").expect("old snapshot");
+        let missing =
+            write_missing_atomically(&path, &[first, second, third], &HashSet::from([second]))
+                .expect("missing snapshot");
+        assert_eq!(missing, 2);
+        assert_eq!(
+            fs::read_to_string(path).expect("snapshot"),
+            format!("{first}\n{third}\n")
+        );
+    }
+}

--- a/crates/pensieve-ingest/src/bin/recover-events.rs
+++ b/crates/pensieve-ingest/src/bin/recover-events.rs
@@ -41,6 +41,12 @@ struct Args {
 }
 
 fn main() {
+    // The workspace enables both rustls providers transitively. Relay connections
+    // cannot choose safely between them without a process-level default.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
+
     if let Err(error) = run() {
         eprintln!("event recovery failed: {error:#}");
         std::process::exit(1);

--- a/crates/pensieve-ingest/src/bin/recover-events.rs
+++ b/crates/pensieve-ingest/src/bin/recover-events.rs
@@ -148,15 +148,23 @@ async fn run() -> Result<()> {
             match result {
                 Ok(events) => {
                     for event in events {
-                        if !target_ids.contains(&event.id) || recovered.contains(&event.id) {
-                            continue;
+                        match append_recovered_event(
+                            &mut writer,
+                            &mut recovered,
+                            &target_ids,
+                            &event,
+                        )? {
+                            AppendOutcome::Added => added += 1,
+                            AppendOutcome::Ignored => {}
+                            AppendOutcome::Invalid { error } => {
+                                eprintln!(
+                                    "invalid_event pass={} batch={} id={} error={error}",
+                                    pass_index + 1,
+                                    batch_index + 1,
+                                    event.id
+                                );
+                            }
                         }
-                        event.verify().with_context(|| {
-                            format!("relay returned invalid event {}", event.id)
-                        })?;
-                        writeln!(writer, "{}", event.as_json())?;
-                        recovered.insert(event.id);
-                        added += 1;
                     }
                     if added > 0 {
                         writer.flush()?;
@@ -275,6 +283,32 @@ fn read_recovered(path: &Path, target_ids: &HashSet<EventId>) -> Result<HashSet<
     Ok(recovered)
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum AppendOutcome {
+    Added,
+    Ignored,
+    Invalid { error: String },
+}
+
+fn append_recovered_event(
+    writer: &mut impl Write,
+    recovered: &mut HashSet<EventId>,
+    target_ids: &HashSet<EventId>,
+    event: &Event,
+) -> Result<AppendOutcome> {
+    if !target_ids.contains(&event.id) || recovered.contains(&event.id) {
+        return Ok(AppendOutcome::Ignored);
+    }
+    if let Err(error) = event.verify() {
+        return Ok(AppendOutcome::Invalid {
+            error: error.to_string(),
+        });
+    }
+    writeln!(writer, "{}", event.as_json())?;
+    recovered.insert(event.id);
+    Ok(AppendOutcome::Added)
+}
+
 fn write_missing_atomically(
     path: &Path,
     ids: &[EventId],
@@ -363,6 +397,41 @@ mod tests {
         fs::write(&output, format!("{}\n", other.as_json())).expect("output");
         let error = read_recovered(&output, &HashSet::from([target.id])).expect_err("non-target");
         assert!(error.to_string().contains("non-target"));
+    }
+
+    #[test]
+    fn invalid_relay_event_is_skipped_without_losing_later_valid_event() {
+        let valid = event("target");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&valid.as_json()).expect("event JSON");
+        let signature = value["sig"].as_str().expect("signature");
+        let first = if signature.starts_with('0') { "1" } else { "0" };
+        value["sig"] = serde_json::Value::String(format!("{first}{}", &signature[1..]));
+        let invalid = Event::from_json(value.to_string()).expect("invalid event shape");
+        assert_eq!(invalid.id, valid.id);
+        assert!(invalid.verify().is_err());
+
+        let targets = HashSet::from([valid.id]);
+        let mut recovered = HashSet::new();
+        let mut output = Vec::new();
+        assert!(matches!(
+            append_recovered_event(&mut output, &mut recovered, &targets, &invalid)
+                .expect("skip invalid event"),
+            AppendOutcome::Invalid { .. }
+        ));
+        assert!(output.is_empty());
+        assert!(recovered.is_empty());
+
+        assert_eq!(
+            append_recovered_event(&mut output, &mut recovered, &targets, &valid)
+                .expect("append valid event"),
+            AppendOutcome::Added
+        );
+        assert_eq!(
+            String::from_utf8(output).expect("UTF-8 JSONL"),
+            format!("{}\n", valid.as_json())
+        );
+        assert_eq!(recovered, targets);
     }
 
     #[test]

--- a/crates/pensieve-lake/src/bin/pensieve-source-manifest.rs
+++ b/crates/pensieve-lake/src/bin/pensieve-source-manifest.rs
@@ -6,9 +6,11 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 use pensieve_lake::{
     ActiveRawFragment, HistoricalSourceManifest, Inventory, audit_historical_completion,
-    read_historical_source_manifest, write_catalog_atomically,
-    write_historical_source_manifest_noclobber,
+    historical_source_exception_from_salvage, read_catalog_fragment,
+    read_historical_source_exceptions, read_historical_source_manifest, write_catalog_atomically,
+    write_historical_source_exceptions_noclobber, write_historical_source_manifest_noclobber,
 };
+use pensieve_parquet::read_salvage_report;
 
 #[derive(Debug, Parser)]
 #[command(about = "Manage the frozen historical notepack source universe")]
@@ -46,6 +48,21 @@ enum Command {
         #[arg(long)]
         manifest: PathBuf,
     },
+    /// Bind terminal-truncation evidence to one published repair work unit.
+    BuildExceptionLedger {
+        /// Frozen historical source manifest.
+        #[arg(long)]
+        manifest: PathBuf,
+        /// Canonical report from `pensieve-notepack-salvage`.
+        #[arg(long)]
+        salvage_report: PathBuf,
+        /// Active-raw catalog fragment containing the published repair work.
+        #[arg(long)]
+        repair_fragment: PathBuf,
+        /// Immutable exception-ledger destination.
+        #[arg(long)]
+        output: PathBuf,
+    },
     /// Audit manifest coverage against a campaign inventory.
     Audit {
         /// Canonical source manifest.
@@ -54,6 +71,12 @@ enum Command {
         /// Existing SQLite campaign inventory.
         #[arg(long)]
         inventory: PathBuf,
+        /// Optional immutable damaged-source exception ledger.
+        #[arg(long)]
+        exceptions: Option<PathBuf>,
+        /// Active-raw repair fragment referenced by the exception ledger.
+        #[arg(long)]
+        repair_fragment: Vec<PathBuf>,
         /// Canonical JSON audit-report destination.
         #[arg(long)]
         output: Option<PathBuf>,
@@ -102,12 +125,40 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 println!("{}\t{}", entry.source_name, entry.source_bytes);
             }
         }
-        Command::Audit {
+        Command::BuildExceptionLedger {
             manifest,
-            inventory,
+            salvage_report,
+            repair_fragment,
             output,
         } => {
             let manifest = read_historical_source_manifest(manifest)?;
+            let report = read_salvage_report(salvage_report)?;
+            let repair_fragment = read_catalog_fragment(repair_fragment)?;
+            let exceptions =
+                historical_source_exception_from_salvage(&manifest, &report, &repair_fragment)?;
+            write_historical_source_exceptions_noclobber(output, &exceptions)?;
+            println!(
+                "exceptions={} manifest={} entries={}",
+                exceptions.exceptions_id,
+                exceptions.manifest_id(),
+                exceptions.entries().len()
+            );
+        }
+        Command::Audit {
+            manifest,
+            inventory,
+            exceptions,
+            repair_fragment,
+            output,
+        } => {
+            let manifest = read_historical_source_manifest(manifest)?;
+            let exceptions = exceptions
+                .map(read_historical_source_exceptions)
+                .transpose()?;
+            let repair_fragments = repair_fragment
+                .into_iter()
+                .map(read_catalog_fragment)
+                .collect::<Result<Vec<_>, _>>()?;
             let mut inventory = Inventory::open_read_only(inventory)?;
             let work_units = inventory.work_units()?;
             let fragment = ActiveRawFragment::export(
@@ -126,6 +177,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 &active_work_unit_ids,
                 fragment.totals().objects,
                 fragment.totals().physical_rows,
+                exceptions.as_ref(),
+                &repair_fragments,
             )?;
             if let Some(output) = output {
                 write_catalog_atomically(output, &audit)?;

--- a/crates/pensieve-lake/src/lib.rs
+++ b/crates/pensieve-lake/src/lib.rs
@@ -23,10 +23,12 @@ pub use inventory::{
 };
 pub use publisher::{LocalObjectStore, PublishedObject, Publisher, S3Publisher, S3PublisherConfig};
 pub use source_manifest::{
-    CompletionProblem, CompletionTotals, HISTORICAL_SOURCE_MANIFEST_FORMAT,
-    HistoricalCompletionAudit, HistoricalSourceEntry, HistoricalSourceManifest,
-    HistoricalSourceTotals, audit_historical_completion, read_historical_source_manifest,
-    write_historical_source_manifest_noclobber,
+    CompletionProblem, CompletionTotals, HISTORICAL_SOURCE_EXCEPTIONS_FORMAT,
+    HISTORICAL_SOURCE_MANIFEST_FORMAT, HistoricalCompletionAudit, HistoricalSourceEntry,
+    HistoricalSourceException, HistoricalSourceExceptions, HistoricalSourceManifest,
+    HistoricalSourceTotals, audit_historical_completion, historical_source_exception_from_salvage,
+    read_historical_source_exceptions, read_historical_source_manifest,
+    write_historical_source_exceptions_noclobber, write_historical_source_manifest_noclobber,
 };
 pub use work_unit::{
     CampaignConfig, CampaignSummary, CleanupSummary, DEFAULT_TARGET_UNCOMPRESSED_BYTES,

--- a/crates/pensieve-lake/src/source_manifest.rs
+++ b/crates/pensieve-lake/src/source_manifest.rs
@@ -8,10 +8,14 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{Error, Result, WorkState, WorkUnitRecord};
+use pensieve_parquet::SalvageReport;
+
+use crate::{ActiveRawFragment, CatalogWorkUnit, Error, Result, WorkState, WorkUnitRecord};
 
 /// Format identifier for the historical notepack source manifest.
 pub const HISTORICAL_SOURCE_MANIFEST_FORMAT: &str = "pensieve.historical-source-manifest.v1";
+/// Format identifier for explicit historical-source repair exceptions.
+pub const HISTORICAL_SOURCE_EXCEPTIONS_FORMAT: &str = "pensieve.historical-source-exceptions.v1";
 
 /// One exact source object selected for the bounded historical campaign.
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -49,6 +53,113 @@ pub struct HistoricalSourceManifest {
     pub manifest_id: String,
     #[serde(flatten)]
     payload: HistoricalSourcePayload,
+}
+
+/// One damaged manifest source resolved through an immutable repair work unit.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct HistoricalSourceException {
+    /// Exact original source name from the frozen manifest.
+    pub source_name: String,
+    /// Exact original source bytes from the frozen manifest and inventory.
+    pub source_bytes: u64,
+    /// SHA-256 observed when the original source failed conversion.
+    pub source_sha256: String,
+    /// Evidence report describing terminal truncation and retained bytes.
+    pub salvage_report_id: String,
+    /// SHA-256 of the complete framed prefix.
+    pub salvaged_source_sha256: String,
+    /// Published repair work unit created from that prefix.
+    pub repair_work_unit_id: String,
+    /// Complete original frames retained in the repair source.
+    pub complete_frames: u64,
+    /// Complete frames expected to enter quarantine.
+    pub rejected_events: u64,
+    /// Zero-based terminal truncated-frame index.
+    pub truncated_frame_index: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct HistoricalSourceExceptionsPayload {
+    format: String,
+    manifest_id: String,
+    entries: Vec<HistoricalSourceException>,
+}
+
+/// Content-addressed exception ledger for a frozen historical manifest.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HistoricalSourceExceptions {
+    /// SHA-256 identity of the compact canonical ledger payload.
+    pub exceptions_id: String,
+    #[serde(flatten)]
+    payload: HistoricalSourceExceptionsPayload,
+}
+
+impl HistoricalSourceExceptions {
+    /// Validated exceptions in source-name order.
+    pub fn entries(&self) -> &[HistoricalSourceException] {
+        &self.payload.entries
+    }
+
+    /// Frozen source-manifest identity covered by this ledger.
+    pub fn manifest_id(&self) -> &str {
+        &self.payload.manifest_id
+    }
+
+    /// Verify ordering, hashes, references, and content identity.
+    pub fn validate(&self) -> Result<()> {
+        if self.payload.format != HISTORICAL_SOURCE_EXCEPTIONS_FORMAT {
+            return Err(Error::InvalidSourceManifest(format!(
+                "unsupported exception-ledger format {}",
+                self.payload.format
+            )));
+        }
+        if self.payload.entries.is_empty() {
+            return Err(Error::InvalidSourceManifest(
+                "exception ledger has no entries".to_owned(),
+            ));
+        }
+        let mut previous = None;
+        for entry in &self.payload.entries {
+            parse_source_name(&entry.source_name)?;
+            if previous.is_some_and(|previous: &str| previous >= entry.source_name.as_str()) {
+                return Err(Error::InvalidSourceManifest(
+                    "exception entries are not strictly ordered by source name".to_owned(),
+                ));
+            }
+            previous = Some(entry.source_name.as_str());
+            for (field, value) in [
+                ("source_sha256", entry.source_sha256.as_str()),
+                (
+                    "salvaged_source_sha256",
+                    entry.salvaged_source_sha256.as_str(),
+                ),
+            ] {
+                validate_sha256(field, value)?;
+            }
+            validate_sha256_id("salvage_report_id", &entry.salvage_report_id)?;
+            let expected_work_id = format!("notepack-sha256-{}", entry.salvaged_source_sha256);
+            if entry.repair_work_unit_id != expected_work_id {
+                return Err(Error::InvalidSourceManifest(format!(
+                    "repair work-unit identity mismatch for {}",
+                    entry.source_name
+                )));
+            }
+            if entry.complete_frames != entry.truncated_frame_index {
+                return Err(Error::InvalidSourceManifest(format!(
+                    "truncated frame does not follow the complete prefix for {}",
+                    entry.source_name
+                )));
+            }
+        }
+        let expected = content_id(&self.payload)?;
+        if self.exceptions_id != expected {
+            return Err(Error::InvalidSourceManifest(format!(
+                "exception-ledger identity mismatch: expected {expected}, found {}",
+                self.exceptions_id
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -260,8 +371,52 @@ pub fn audit_historical_completion(
     active_work_unit_ids: &BTreeSet<String>,
     active_raw_objects: u64,
     active_raw_rows: u64,
+    exceptions: Option<&HistoricalSourceExceptions>,
+    repair_fragments: &[ActiveRawFragment],
 ) -> Result<HistoricalCompletionAudit> {
     manifest.validate()?;
+    if let Some(exceptions) = exceptions {
+        exceptions.validate()?;
+        if exceptions.manifest_id() != manifest.manifest_id {
+            return Err(Error::InvalidSourceManifest(
+                "exception ledger references a different source manifest".to_owned(),
+            ));
+        }
+    } else if !repair_fragments.is_empty() {
+        return Err(Error::InvalidSourceManifest(
+            "repair fragments require an exception ledger".to_owned(),
+        ));
+    }
+    let exception_by_source: BTreeMap<_, _> = exceptions
+        .into_iter()
+        .flat_map(HistoricalSourceExceptions::entries)
+        .map(|entry| (entry.source_name.as_str(), entry))
+        .collect();
+    let mut repair_by_id = BTreeMap::<String, (&CatalogWorkUnit, u64)>::new();
+    for fragment in repair_fragments {
+        fragment.validate()?;
+        for work in fragment.work_units() {
+            let object_count = u64::try_from(
+                fragment
+                    .objects()
+                    .iter()
+                    .filter(|object| object.work_unit_id == work.work_unit_id)
+                    .count(),
+            )
+            .map_err(|_| {
+                Error::InvalidSourceManifest("repair object count exceeds u64".to_owned())
+            })?;
+            if let Some((existing, existing_objects)) =
+                repair_by_id.insert(work.work_unit_id.clone(), (work, object_count))
+                && (existing != work || existing_objects != object_count)
+            {
+                return Err(Error::InvalidSourceManifest(format!(
+                    "conflicting repair coverage for {}",
+                    work.work_unit_id
+                )));
+            }
+        }
+    }
     let manifest_names: BTreeSet<_> = manifest
         .entries()
         .iter()
@@ -320,6 +475,87 @@ pub fn audit_historical_completion(
             work.state,
             WorkState::Published | WorkState::SourceCommitted
         ) {
+            if let Some(exception) = exception_by_source.get(entry.source_name.as_str()) {
+                if exception.source_bytes != entry.source_bytes {
+                    problems.push(CompletionProblem {
+                        source_name: entry.source_name.clone(),
+                        reason: "exception source bytes differ from frozen manifest".to_owned(),
+                    });
+                    continue;
+                }
+                if work.state != WorkState::Failed {
+                    problems.push(CompletionProblem {
+                        source_name: entry.source_name.clone(),
+                        reason: format!(
+                            "source exception requires failed original work, found {}",
+                            work.state
+                        ),
+                    });
+                    continue;
+                }
+                if work.source_sha256 != exception.source_sha256 {
+                    problems.push(CompletionProblem {
+                        source_name: entry.source_name.clone(),
+                        reason: "failed source checksum differs from exception evidence".to_owned(),
+                    });
+                    continue;
+                }
+                let Some((repair, repair_objects)) =
+                    repair_by_id.get(&exception.repair_work_unit_id)
+                else {
+                    problems.push(CompletionProblem {
+                        source_name: entry.source_name.clone(),
+                        reason: format!(
+                            "repair work {} is absent from active repair fragments",
+                            exception.repair_work_unit_id
+                        ),
+                    });
+                    continue;
+                };
+                if repair.source_sha256 != exception.salvaged_source_sha256
+                    || repair.input_events != exception.complete_frames
+                    || repair.rejected_events != exception.rejected_events
+                {
+                    problems.push(CompletionProblem {
+                        source_name: entry.source_name.clone(),
+                        reason: "active repair work differs from exception evidence".to_owned(),
+                    });
+                    continue;
+                }
+                let Some(accounted) = repair.output_rows.checked_add(repair.rejected_events) else {
+                    return Err(Error::InvalidSourceManifest(
+                        "repair event accounting overflows".to_owned(),
+                    ));
+                };
+                let Some(duplicate_events) = repair.input_events.checked_sub(accounted) else {
+                    problems.push(CompletionProblem {
+                        source_name: entry.source_name.clone(),
+                        reason: "repair output plus rejects exceeds input".to_owned(),
+                    });
+                    continue;
+                };
+                add_completion_totals(
+                    &mut totals,
+                    repair.output_rows,
+                    repair.rejected_events,
+                    duplicate_events,
+                )?;
+                totals.active_raw_rows = totals
+                    .active_raw_rows
+                    .checked_add(repair.output_rows)
+                    .ok_or_else(|| {
+                        Error::InvalidSourceManifest("active repair row count overflows".to_owned())
+                    })?;
+                totals.active_raw_objects = totals
+                    .active_raw_objects
+                    .checked_add(*repair_objects)
+                    .ok_or_else(|| {
+                        Error::InvalidSourceManifest(
+                            "active repair object count overflows".to_owned(),
+                        )
+                    })?;
+                continue;
+            }
             problems.push(CompletionProblem {
                 source_name: entry.source_name.clone(),
                 reason: format!("work unit is {}", work.state),
@@ -346,27 +582,12 @@ pub fn audit_historical_completion(
             });
             continue;
         };
-        totals.published_sources = totals.published_sources.checked_add(1).ok_or_else(|| {
-            Error::InvalidSourceManifest("published source count overflows u64".to_owned())
-        })?;
-        totals.output_rows = totals
-            .output_rows
-            .checked_add(work.output_rows)
-            .ok_or_else(|| {
-                Error::InvalidSourceManifest("output row count overflows u64".to_owned())
-            })?;
-        totals.rejected_events = totals
-            .rejected_events
-            .checked_add(work.rejected_events)
-            .ok_or_else(|| {
-                Error::InvalidSourceManifest("rejected event count overflows u64".to_owned())
-            })?;
-        totals.duplicate_events = totals
-            .duplicate_events
-            .checked_add(duplicate_events)
-            .ok_or_else(|| {
-                Error::InvalidSourceManifest("duplicate event count overflows u64".to_owned())
-            })?;
+        add_completion_totals(
+            &mut totals,
+            work.output_rows,
+            work.rejected_events,
+            duplicate_events,
+        )?;
     }
 
     for source_name in by_source.keys() {
@@ -374,6 +595,14 @@ pub fn audit_historical_completion(
             problems.push(CompletionProblem {
                 source_name: source_name.clone(),
                 reason: "inventory work is outside the frozen historical manifest".to_owned(),
+            });
+        }
+    }
+    for source_name in exception_by_source.keys() {
+        if !manifest_names.contains(source_name) {
+            problems.push(CompletionProblem {
+                source_name: (*source_name).to_owned(),
+                reason: "exception source is outside the frozen historical manifest".to_owned(),
             });
         }
     }
@@ -400,6 +629,34 @@ pub fn audit_historical_completion(
         audit_id: content_id(&payload)?,
         payload,
     })
+}
+
+fn add_completion_totals(
+    totals: &mut CompletionTotals,
+    output_rows: u64,
+    rejected_events: u64,
+    duplicate_events: u64,
+) -> Result<()> {
+    totals.published_sources = totals.published_sources.checked_add(1).ok_or_else(|| {
+        Error::InvalidSourceManifest("published source count overflows u64".to_owned())
+    })?;
+    totals.output_rows = totals
+        .output_rows
+        .checked_add(output_rows)
+        .ok_or_else(|| Error::InvalidSourceManifest("output row count overflows u64".to_owned()))?;
+    totals.rejected_events = totals
+        .rejected_events
+        .checked_add(rejected_events)
+        .ok_or_else(|| {
+            Error::InvalidSourceManifest("rejected event count overflows u64".to_owned())
+        })?;
+    totals.duplicate_events = totals
+        .duplicate_events
+        .checked_add(duplicate_events)
+        .ok_or_else(|| {
+            Error::InvalidSourceManifest("duplicate event count overflows u64".to_owned())
+        })?;
+    Ok(())
 }
 
 /// Read and fully validate a canonical source manifest.
@@ -440,6 +697,91 @@ pub fn write_historical_source_manifest_noclobber(
     })?;
     File::open(parent)?.sync_all()?;
     Ok(())
+}
+
+/// Build a one-entry exception ledger from validated salvage and repair evidence.
+pub fn historical_source_exception_from_salvage(
+    manifest: &HistoricalSourceManifest,
+    report: &SalvageReport,
+    repair_fragment: &ActiveRawFragment,
+) -> Result<HistoricalSourceExceptions> {
+    manifest.validate()?;
+    report.validate().map_err(|error| {
+        Error::InvalidSourceManifest(format!("invalid salvage report: {error}"))
+    })?;
+    repair_fragment.validate()?;
+    let source = manifest
+        .entries()
+        .iter()
+        .find(|entry| entry.source_name == report.source_name())
+        .ok_or_else(|| {
+            Error::InvalidSourceManifest(format!(
+                "salvage source {} is absent from the frozen manifest",
+                report.source_name()
+            ))
+        })?;
+    if source.source_bytes != report.source_bytes() {
+        return Err(Error::InvalidSourceManifest(format!(
+            "salvage source bytes differ from the manifest for {}",
+            report.source_name()
+        )));
+    }
+    let repair_work_unit_id = format!("notepack-sha256-{}", report.salvaged_segment_sha256());
+    let repair = repair_fragment
+        .work_units()
+        .iter()
+        .find(|work| work.work_unit_id == repair_work_unit_id)
+        .ok_or_else(|| {
+            Error::InvalidSourceManifest(format!(
+                "repair fragment does not contain {repair_work_unit_id}"
+            ))
+        })?;
+    validate_repair_accounting(report, repair)?;
+    let payload = HistoricalSourceExceptionsPayload {
+        format: HISTORICAL_SOURCE_EXCEPTIONS_FORMAT.to_owned(),
+        manifest_id: manifest.manifest_id.clone(),
+        entries: vec![HistoricalSourceException {
+            source_name: source.source_name.clone(),
+            source_bytes: source.source_bytes,
+            source_sha256: report.source_sha256().to_owned(),
+            salvage_report_id: report.report_id.clone(),
+            salvaged_source_sha256: report.salvaged_segment_sha256().to_owned(),
+            repair_work_unit_id,
+            complete_frames: report.complete_frames(),
+            rejected_events: report.rejected_events(),
+            truncated_frame_index: report.truncated_frame_index(),
+        }],
+    };
+    let exceptions = HistoricalSourceExceptions {
+        exceptions_id: content_id(&payload)?,
+        payload,
+    };
+    exceptions.validate()?;
+    Ok(exceptions)
+}
+
+/// Read and fully validate a canonical historical exception ledger.
+pub fn read_historical_source_exceptions(
+    path: impl AsRef<Path>,
+) -> Result<HistoricalSourceExceptions> {
+    let bytes = fs::read(path)?;
+    let exceptions: HistoricalSourceExceptions = serde_json::from_slice(&bytes)?;
+    exceptions.validate()?;
+    if bytes != canonical_json(&exceptions)? {
+        return Err(Error::InvalidSourceManifest(
+            "exception-ledger JSON is not canonically encoded".to_owned(),
+        ));
+    }
+    Ok(exceptions)
+}
+
+/// Create a canonical exception ledger without replacing existing evidence.
+pub fn write_historical_source_exceptions_noclobber(
+    path: impl AsRef<Path>,
+    exceptions: &HistoricalSourceExceptions,
+) -> Result<()> {
+    exceptions.validate()?;
+    write_json_noclobber(path.as_ref(), &canonical_json(exceptions)?)
 }
 
 fn parse_source_name(name: &str) -> Result<(u64, bool)> {
@@ -542,6 +884,81 @@ fn source_totals(entries: &[HistoricalSourceEntry]) -> Result<HistoricalSourceTo
     })
 }
 
+fn validate_repair_accounting(report: &SalvageReport, repair: &CatalogWorkUnit) -> Result<()> {
+    if repair.source_sha256 != report.salvaged_segment_sha256() {
+        return Err(Error::InvalidSourceManifest(format!(
+            "repair source checksum differs from salvage report for {}",
+            report.source_name()
+        )));
+    }
+    if repair.input_events != report.complete_frames() {
+        return Err(Error::InvalidSourceManifest(format!(
+            "repair input count differs from salvage report for {}",
+            report.source_name()
+        )));
+    }
+    if repair.rejected_events != report.rejected_events() {
+        return Err(Error::InvalidSourceManifest(format!(
+            "repair reject count differs from salvage report for {}",
+            report.source_name()
+        )));
+    }
+    let accounted = repair
+        .output_rows
+        .checked_add(repair.rejected_events)
+        .ok_or_else(|| Error::InvalidSourceManifest("repair accounting overflows".to_owned()))?;
+    if accounted > repair.input_events {
+        return Err(Error::InvalidSourceManifest(format!(
+            "repair output plus rejects exceeds input for {}",
+            report.source_name()
+        )));
+    }
+    Ok(())
+}
+
+fn write_json_noclobber(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path.parent().filter(|path| !path.as_os_str().is_empty());
+    let parent = parent.unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    temporary.write_all(bytes)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary.persist_noclobber(path).map_err(|error| {
+        if error.error.kind() == std::io::ErrorKind::AlreadyExists {
+            Error::InvalidSourceManifest(format!(
+                "refusing to replace frozen evidence {}",
+                path.display()
+            ))
+        } else {
+            Error::Io(error.error)
+        }
+    })?;
+    File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn validate_sha256(field: &str, value: &str) -> Result<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(Error::InvalidSourceManifest(format!(
+            "{field} is not lowercase SHA-256"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sha256_id(field: &str, value: &str) -> Result<()> {
+    let Some(digest) = value.strip_prefix("sha256:") else {
+        return Err(Error::InvalidSourceManifest(format!(
+            "{field} is not a SHA-256 content ID"
+        )));
+    };
+    validate_sha256(field, digest)
+}
+
 fn canonical_json(value: &impl Serialize) -> Result<Vec<u8>> {
     let mut bytes = serde_json::to_vec_pretty(value)?;
     bytes.push(b'\n');
@@ -558,6 +975,8 @@ fn content_id(value: &impl Serialize) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+
+    use crate::{Inventory, ObjectKind, ObjectRecord, ObjectState, WorkUnitRegistration};
 
     use super::*;
 
@@ -681,6 +1100,8 @@ mod tests {
             &BTreeSet::from(["work-published".to_owned()]),
             1,
             2,
+            None,
+            &[],
         )
         .expect("audit");
 
@@ -699,6 +1120,113 @@ mod tests {
                 .iter()
                 .any(|problem| problem.reason.contains("outside"))
         );
+    }
+
+    #[test]
+    fn terminal_truncation_exception_requires_and_accounts_for_active_repair() {
+        let manifest = HistoricalSourceManifest::from_rclone_lsjson(
+            &lsjson(&[("segment-000000000.notepack.gz", 50)]),
+            0,
+        )
+        .expect("manifest");
+        let mut failed = work(
+            "original-work",
+            "segment-000000000.notepack.gz",
+            50,
+            WorkState::Failed,
+        );
+        failed.source_sha256 = "bb".repeat(32);
+        let repair_sha = "aa".repeat(32);
+        let repair_id = format!("notepack-sha256-{repair_sha}");
+        let mut repair_inventory = Inventory::open_in_memory().expect("repair inventory");
+        repair_inventory
+            .ensure_work_unit(&WorkUnitRegistration {
+                id: &repair_id,
+                source_path: Path::new("/repair/salvaged.notepack"),
+                source_bytes: 40,
+                source_sha256: &repair_sha,
+                target_uncompressed_bytes: 1_000,
+                max_event_bytes: 2_000,
+                object_prefix: "nostr/v1",
+                writer_version: "test",
+            })
+            .expect("register repair");
+        repair_inventory
+            .transition_work(&repair_id, WorkState::Writing, None)
+            .expect("write repair");
+        let object_key = format!("nostr/v1/raw/{repair_id}/part-00000.parquet");
+        repair_inventory
+            .record_validated_objects(
+                &repair_id,
+                2,
+                1,
+                1,
+                &[ObjectRecord {
+                    object_key: object_key.clone(),
+                    work_unit_id: repair_id.clone(),
+                    part_number: 0,
+                    kind: ObjectKind::Parquet,
+                    state: ObjectState::Validated,
+                    local_path: PathBuf::from("/staging/repair.parquet"),
+                    byte_size: 20,
+                    sha256: "cc".repeat(32),
+                    writer_version: "test".to_owned(),
+                    row_count: 1,
+                    min_created_at: Some(1),
+                    max_created_at: Some(1),
+                }],
+            )
+            .expect("validate repair");
+        repair_inventory
+            .transition_work(&repair_id, WorkState::Uploading, None)
+            .expect("upload repair");
+        repair_inventory
+            .mark_object_uploaded(&object_key)
+            .expect("mark uploaded");
+        repair_inventory
+            .transition_work(&repair_id, WorkState::Uploaded, None)
+            .expect("finish upload");
+        repair_inventory
+            .activate_work_unit(&repair_id)
+            .expect("activate repair");
+        let repair_fragment =
+            ActiveRawFragment::export(&mut repair_inventory, "repair", "s3://test")
+                .expect("repair fragment");
+        let payload = HistoricalSourceExceptionsPayload {
+            format: HISTORICAL_SOURCE_EXCEPTIONS_FORMAT.to_owned(),
+            manifest_id: manifest.manifest_id.clone(),
+            entries: vec![HistoricalSourceException {
+                source_name: "segment-000000000.notepack.gz".to_owned(),
+                source_bytes: 50,
+                source_sha256: "bb".repeat(32),
+                salvage_report_id: format!("sha256:{}", "dd".repeat(32)),
+                salvaged_source_sha256: repair_sha,
+                repair_work_unit_id: repair_id,
+                complete_frames: 2,
+                rejected_events: 1,
+                truncated_frame_index: 2,
+            }],
+        };
+        let exceptions = HistoricalSourceExceptions {
+            exceptions_id: content_id(&payload).expect("exception ID"),
+            payload,
+        };
+
+        let audit = audit_historical_completion(
+            &manifest,
+            &[failed],
+            &BTreeSet::new(),
+            0,
+            0,
+            Some(&exceptions),
+            &[repair_fragment],
+        )
+        .expect("completion audit");
+        assert!(audit.is_complete());
+        assert_eq!(audit.totals().published_sources, 1);
+        assert_eq!(audit.totals().output_rows, 1);
+        assert_eq!(audit.totals().rejected_events, 1);
+        assert_eq!(audit.totals().active_raw_rows, 1);
     }
 
     fn work(id: &str, source_name: &str, source_bytes: u64, state: WorkState) -> WorkUnitRecord {

--- a/crates/pensieve-parquet/Cargo.toml
+++ b/crates/pensieve-parquet/Cargo.toml
@@ -22,9 +22,11 @@ hex.workspace = true
 nostr.workspace = true
 notepack.workspace = true
 parquet.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
 tempfile = "3"
 thiserror.workspace = true
 
 [dev-dependencies]
 bytes = "1"
-serde_json.workspace = true

--- a/crates/pensieve-parquet/src/bin/pensieve-notepack-salvage.rs
+++ b/crates/pensieve-parquet/src/bin/pensieve-notepack-salvage.rs
@@ -1,0 +1,43 @@
+//! Create an evidence-preserving repair bundle for a terminally truncated segment.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use pensieve_parquet::{DEFAULT_MAX_EVENT_BYTES, salvage_truncated_segment};
+
+#[derive(Debug, Parser)]
+#[command(about = "Salvage the complete prefix of a terminally truncated notepack segment")]
+struct Args {
+    /// Original plain or gzip notepack segment.
+    input: PathBuf,
+    /// New bundle directory; an existing destination is never replaced.
+    output_directory: PathBuf,
+    /// Maximum accepted declared event frame size.
+    #[arg(long, default_value_t = DEFAULT_MAX_EVENT_BYTES)]
+    max_event_bytes: usize,
+}
+
+fn main() {
+    let args = Args::parse();
+    match salvage_truncated_segment(args.input, &args.output_directory, args.max_event_bytes) {
+        Ok(report) => println!(
+            concat!(
+                "report={} source={} source_sha256={} complete_frames={} valid={} rejected={} ",
+                "truncated_frame={} salvaged_sha256={} bundle={}"
+            ),
+            report.report_id,
+            report.source_name(),
+            report.source_sha256(),
+            report.complete_frames(),
+            report.valid_events(),
+            report.rejected_events(),
+            report.truncated_frame_index(),
+            report.salvaged_segment_sha256(),
+            args.output_directory.display()
+        ),
+        Err(error) => {
+            eprintln!("notepack salvage failed: {error}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/pensieve-parquet/src/error.rs
+++ b/crates/pensieve-parquet/src/error.rs
@@ -61,6 +61,14 @@ pub enum Error {
         frame_index: usize,
     },
 
+    /// A salvage operation was requested for a structurally complete segment.
+    #[error("notepack segment is complete; refusing to create a salvage artifact")]
+    SegmentNotTruncated,
+
+    /// A salvage bundle or its requested destination is invalid.
+    #[error("invalid notepack salvage: {0}")]
+    InvalidSalvage(String),
+
     /// A framed notepack payload failed decoding or canonical validation.
     #[error("notepack frame {frame_index} failed validation: {source}")]
     FrameValidation {

--- a/crates/pensieve-parquet/src/lib.rs
+++ b/crates/pensieve-parquet/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod error;
 mod row;
+mod salvage;
 mod schema;
 mod segment;
 mod validator;
@@ -13,6 +14,10 @@ mod writer;
 
 pub use error::{Error, Result};
 pub use row::{CanonicalEvent, RawEvent};
+pub use salvage::{
+    NOTEPACK_SALVAGE_FORMAT, SALVAGE_REPORT_NAME, SALVAGED_SEGMENT_NAME, SalvageReport,
+    TRUNCATED_TAIL_NAME, read_salvage_report, salvage_truncated_segment,
+};
 pub use schema::{
     ARCHIVE_VERSION, ARCHIVE_VERSION_KEY, ROW_GROUP_TARGET_BYTES, canonical_arrow_schema,
 };

--- a/crates/pensieve-parquet/src/salvage.rs
+++ b/crates/pensieve-parquet/src/salvage.rs
@@ -1,0 +1,355 @@
+//! Evidence-preserving recovery for a terminally truncated notepack segment.
+
+use std::fs::{self, File};
+use std::io::{BufReader, Read, Write};
+use std::path::Path;
+
+use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{CanonicalEvent, Error, Result};
+
+/// Format identifier for a terminal-truncation salvage report.
+pub const NOTEPACK_SALVAGE_FORMAT: &str = "pensieve.notepack-salvage.v1";
+/// Complete framed notepack prefix retained by a salvage bundle.
+pub const SALVAGED_SEGMENT_NAME: &str = "salvaged.notepack";
+/// Exact decompressed bytes of the incomplete terminal frame.
+pub const TRUNCATED_TAIL_NAME: &str = "truncated-tail.bin";
+/// Canonical evidence report within a salvage bundle.
+pub const SALVAGE_REPORT_NAME: &str = "report.json";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct SalvagePayload {
+    format: String,
+    source_name: String,
+    source_bytes: u64,
+    source_sha256: String,
+    max_event_bytes: u64,
+    complete_frames: u64,
+    valid_events: u64,
+    rejected_events: u64,
+    truncated_frame_index: u64,
+    declared_frame_bytes: Option<u64>,
+    retained_tail_bytes: u64,
+    salvaged_segment_bytes: u64,
+    salvaged_segment_sha256: String,
+    truncated_tail_sha256: String,
+}
+
+/// Content-addressed report for one atomically published salvage bundle.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SalvageReport {
+    /// SHA-256 identity of the compact canonical report payload.
+    pub report_id: String,
+    #[serde(flatten)]
+    payload: SalvagePayload,
+}
+
+impl SalvageReport {
+    /// Original source filename.
+    pub fn source_name(&self) -> &str {
+        &self.payload.source_name
+    }
+
+    /// Original source SHA-256.
+    pub fn source_sha256(&self) -> &str {
+        &self.payload.source_sha256
+    }
+
+    /// Number of structurally complete frames retained.
+    pub fn complete_frames(&self) -> u64 {
+        self.payload.complete_frames
+    }
+
+    /// Number of complete frames that passed canonical event validation.
+    pub fn valid_events(&self) -> u64 {
+        self.payload.valid_events
+    }
+
+    /// Number of complete frames retained for later quarantine.
+    pub fn rejected_events(&self) -> u64 {
+        self.payload.rejected_events
+    }
+
+    /// Zero-based index of the incomplete terminal frame.
+    pub fn truncated_frame_index(&self) -> u64 {
+        self.payload.truncated_frame_index
+    }
+
+    /// SHA-256 of the complete framed prefix.
+    pub fn salvaged_segment_sha256(&self) -> &str {
+        &self.payload.salvaged_segment_sha256
+    }
+
+    /// Exact source bytes observed during salvage.
+    pub fn source_bytes(&self) -> u64 {
+        self.payload.source_bytes
+    }
+
+    /// Verify report structure, accounting, hashes, and content identity.
+    pub fn validate(&self) -> Result<()> {
+        if self.payload.format != NOTEPACK_SALVAGE_FORMAT {
+            return Err(Error::InvalidSalvage(format!(
+                "unsupported report format {}",
+                self.payload.format
+            )));
+        }
+        let accounted = self
+            .payload
+            .valid_events
+            .checked_add(self.payload.rejected_events)
+            .ok_or_else(|| Error::InvalidSalvage("event accounting overflows".to_owned()))?;
+        if self.payload.complete_frames != accounted {
+            return Err(Error::InvalidSalvage(
+                "complete-frame accounting does not reconcile".to_owned(),
+            ));
+        }
+        if self.payload.truncated_frame_index != self.payload.complete_frames {
+            return Err(Error::InvalidSalvage(
+                "truncated frame does not immediately follow the complete prefix".to_owned(),
+            ));
+        }
+        for (field, value) in [
+            ("source_sha256", &self.payload.source_sha256),
+            (
+                "salvaged_segment_sha256",
+                &self.payload.salvaged_segment_sha256,
+            ),
+            ("truncated_tail_sha256", &self.payload.truncated_tail_sha256),
+        ] {
+            if value.len() != 64
+                || !value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            {
+                return Err(Error::InvalidSalvage(format!(
+                    "{field} is not lowercase SHA-256"
+                )));
+            }
+        }
+        let expected = content_id(&self.payload)?;
+        if self.report_id != expected {
+            return Err(Error::InvalidSalvage(format!(
+                "report identity mismatch: expected {expected}, found {}",
+                self.report_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Read and fully validate a canonical salvage report.
+pub fn read_salvage_report(path: impl AsRef<Path>) -> Result<SalvageReport> {
+    let bytes = fs::read(path)?;
+    let report: SalvageReport =
+        serde_json::from_slice(&bytes).map_err(|error| Error::InvalidSalvage(error.to_string()))?;
+    report.validate()?;
+    if bytes != canonical_json(&report)? {
+        return Err(Error::InvalidSalvage(
+            "report JSON is not canonically encoded".to_owned(),
+        ));
+    }
+    Ok(report)
+}
+
+/// Preserve every complete frame and the exact incomplete terminal bytes.
+///
+/// The destination is an atomically renamed directory containing a plain
+/// framed notepack prefix, the incomplete decompressed tail, and a canonical
+/// content-addressed report. Complete invalid frames remain in the salvaged
+/// segment so the normal campaign can quarantine them. A complete input is not
+/// a salvage case and is rejected without creating output.
+pub fn salvage_truncated_segment(
+    input: impl AsRef<Path>,
+    output_directory: impl AsRef<Path>,
+    max_event_bytes: usize,
+) -> Result<SalvageReport> {
+    let input = input.as_ref();
+    let output_directory = output_directory.as_ref();
+    if output_directory.exists() {
+        return Err(Error::OutputExists {
+            path: output_directory.to_owned(),
+        });
+    }
+    let source_name = input
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| Error::InvalidSalvage("source filename is not UTF-8".to_owned()))?
+        .to_owned();
+    let source_bytes = input.metadata()?.len();
+    let source_sha256 = sha256_file(input)?;
+    let parent = output_directory
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let temporary = tempfile::Builder::new()
+        .prefix(".notepack-salvage-")
+        .tempdir_in(parent)?;
+    let salvaged_path = temporary.path().join(SALVAGED_SEGMENT_NAME);
+    let tail_path = temporary.path().join(TRUNCATED_TAIL_NAME);
+    let report_path = temporary.path().join(SALVAGE_REPORT_NAME);
+    let mut salvaged = File::create(&salvaged_path)?;
+    let mut reader = open_segment(input)?;
+    let scan = copy_complete_prefix(&mut reader, &mut salvaged, &tail_path, max_event_bytes)?;
+    salvaged.flush()?;
+    salvaged.sync_all()?;
+    File::open(&tail_path)?.sync_all()?;
+
+    let payload = SalvagePayload {
+        format: NOTEPACK_SALVAGE_FORMAT.to_owned(),
+        source_name,
+        source_bytes,
+        source_sha256,
+        max_event_bytes: to_u64(max_event_bytes, "max_event_bytes")?,
+        complete_frames: to_u64(scan.complete_frames, "complete_frames")?,
+        valid_events: to_u64(scan.valid_events, "valid_events")?,
+        rejected_events: to_u64(scan.rejected_events, "rejected_events")?,
+        truncated_frame_index: to_u64(scan.complete_frames, "truncated_frame_index")?,
+        declared_frame_bytes: scan
+            .declared_frame_bytes
+            .map(|value| to_u64(value, "declared_frame_bytes"))
+            .transpose()?,
+        retained_tail_bytes: tail_path.metadata()?.len(),
+        salvaged_segment_bytes: salvaged_path.metadata()?.len(),
+        salvaged_segment_sha256: sha256_file(&salvaged_path)?,
+        truncated_tail_sha256: sha256_file(&tail_path)?,
+    };
+    let report = SalvageReport {
+        report_id: content_id(&payload)?,
+        payload,
+    };
+    report.validate()?;
+    let mut report_file = File::create(&report_path)?;
+    report_file.write_all(&canonical_json(&report)?)?;
+    report_file.sync_all()?;
+    File::open(temporary.path())?.sync_all()?;
+
+    let temporary_path = temporary.keep();
+    if let Err(error) = fs::rename(&temporary_path, output_directory) {
+        let _ = fs::remove_dir_all(&temporary_path);
+        return Err(error.into());
+    }
+    File::open(parent)?.sync_all()?;
+    Ok(report)
+}
+
+#[derive(Debug)]
+struct PrefixScan {
+    complete_frames: usize,
+    valid_events: usize,
+    rejected_events: usize,
+    declared_frame_bytes: Option<usize>,
+}
+
+fn copy_complete_prefix(
+    reader: &mut impl Read,
+    salvaged: &mut impl Write,
+    tail_path: &Path,
+    max_event_bytes: usize,
+) -> Result<PrefixScan> {
+    let mut complete_frames = 0usize;
+    let mut valid_events = 0usize;
+    let mut rejected_events = 0usize;
+    loop {
+        let mut length_bytes = [0u8; 4];
+        let length_bytes_read = read_until_eof(reader, &mut length_bytes)?;
+        if length_bytes_read == 0 {
+            return Err(Error::SegmentNotTruncated);
+        }
+        if length_bytes_read < length_bytes.len() {
+            fs::write(tail_path, &length_bytes[..length_bytes_read])?;
+            return Ok(PrefixScan {
+                complete_frames,
+                valid_events,
+                rejected_events,
+                declared_frame_bytes: None,
+            });
+        }
+        let length = u32::from_le_bytes(length_bytes) as usize;
+        if length > max_event_bytes {
+            return Err(Error::FrameTooLarge {
+                length,
+                limit: max_event_bytes,
+            });
+        }
+        let mut payload = vec![0u8; length];
+        let payload_bytes_read = read_until_eof(reader, &mut payload)?;
+        if payload_bytes_read < length {
+            let mut tail = File::create(tail_path)?;
+            tail.write_all(&length_bytes)?;
+            tail.write_all(&payload[..payload_bytes_read])?;
+            tail.flush()?;
+            return Ok(PrefixScan {
+                complete_frames,
+                valid_events,
+                rejected_events,
+                declared_frame_bytes: Some(length),
+            });
+        }
+
+        salvaged.write_all(&length_bytes)?;
+        salvaged.write_all(&payload)?;
+        if CanonicalEvent::from_notepack(&payload).is_ok() {
+            valid_events += 1;
+        } else {
+            rejected_events += 1;
+        }
+        complete_frames += 1;
+    }
+}
+
+fn read_until_eof(reader: &mut impl Read, destination: &mut [u8]) -> Result<usize> {
+    let mut read = 0usize;
+    while read < destination.len() {
+        match reader.read(&mut destination[read..]) {
+            Ok(0) => break,
+            Ok(count) => read += count,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(read)
+}
+
+fn open_segment(path: &Path) -> Result<Box<dyn Read>> {
+    let file = File::open(path)?;
+    if path.extension().is_some_and(|extension| extension == "gz") {
+        Ok(Box::new(GzDecoder::new(BufReader::new(file))))
+    } else {
+        Ok(Box::new(BufReader::new(file)))
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 128 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn canonical_json(value: &impl Serialize) -> Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec_pretty(value)
+        .map_err(|error| Error::InvalidSalvage(error.to_string()))?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn content_id(value: &impl Serialize) -> Result<String> {
+    let bytes =
+        serde_json::to_vec(value).map_err(|error| Error::InvalidSalvage(error.to_string()))?;
+    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+fn to_u64(value: usize, field: &str) -> Result<u64> {
+    u64::try_from(value)
+        .map_err(|_| Error::InvalidSalvage(format!("{field} cannot be represented as u64")))
+}

--- a/crates/pensieve-parquet/tests/conversion.rs
+++ b/crates/pensieve-parquet/tests/conversion.rs
@@ -6,8 +6,9 @@ use flate2::write::GzEncoder;
 use nostr::{Event, EventBuilder, Keys, Kind, Tag, Timestamp};
 use notepack::NoteBinary;
 use pensieve_parquet::{
-    DEFAULT_MAX_EVENT_BYTES, Error, convert_segment, convert_segment_quarantining_invalid,
-    scan_framed_notepack, validate_file,
+    DEFAULT_MAX_EVENT_BYTES, Error, SALVAGE_REPORT_NAME, SALVAGED_SEGMENT_NAME, SalvageReport,
+    TRUNCATED_TAIL_NAME, convert_segment, convert_segment_quarantining_invalid,
+    read_salvage_report, salvage_truncated_segment, scan_framed_notepack, validate_file,
 };
 
 fn test_keys() -> Keys {
@@ -142,4 +143,69 @@ fn truncated_segment_never_publishes_an_output_file() {
         Err(Error::TruncatedFrame { frame_index: 0 })
     ));
     assert!(!output.exists());
+}
+
+#[test]
+fn terminal_truncation_salvage_preserves_complete_frames_and_exact_tail() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let input = directory.path().join("segment-000000001.notepack");
+    let bundle = directory.path().join("salvage");
+    let valid = pack(&event(1, "valid"));
+    let mut segment = File::create(&input).expect("input segment");
+    write_frame(&mut segment, &[1, 2, 3]);
+    write_frame(&mut segment, &valid);
+    segment
+        .write_all(&10u32.to_le_bytes())
+        .expect("tail length");
+    segment.write_all(&[4, 5, 6]).expect("tail payload");
+    segment.sync_all().expect("sync input");
+
+    let report = salvage_truncated_segment(&input, &bundle, DEFAULT_MAX_EVENT_BYTES)
+        .expect("salvage terminal truncation");
+    assert_eq!(report.complete_frames(), 2);
+    assert_eq!(report.valid_events(), 1);
+    assert_eq!(report.rejected_events(), 1);
+    assert_eq!(report.truncated_frame_index(), 2);
+
+    let scan = scan_framed_notepack(
+        File::open(bundle.join(SALVAGED_SEGMENT_NAME)).expect("salvaged segment"),
+        DEFAULT_MAX_EVENT_BYTES,
+    )
+    .expect("complete salvaged prefix");
+    assert_eq!(scan.events.len(), 1);
+    assert_eq!(scan.rejected.len(), 1);
+    let mut expected_tail = 10u32.to_le_bytes().to_vec();
+    expected_tail.extend([4, 5, 6]);
+    assert_eq!(
+        fs::read(bundle.join(TRUNCATED_TAIL_NAME)).expect("tail"),
+        expected_tail
+    );
+    let stored_report: SalvageReport =
+        serde_json::from_slice(&fs::read(bundle.join(SALVAGE_REPORT_NAME)).expect("report"))
+            .expect("canonical report JSON");
+    assert_eq!(stored_report, report);
+    assert_eq!(
+        read_salvage_report(bundle.join(SALVAGE_REPORT_NAME)).expect("validated report"),
+        report
+    );
+    assert!(matches!(
+        salvage_truncated_segment(&input, &bundle, DEFAULT_MAX_EVENT_BYTES),
+        Err(Error::OutputExists { .. })
+    ));
+}
+
+#[test]
+fn complete_segment_is_not_silently_reclassified_as_salvage() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let input = directory.path().join("complete.notepack");
+    let bundle = directory.path().join("salvage");
+    let mut segment = File::create(&input).expect("input segment");
+    write_frame(&mut segment, &pack(&event(1, "complete")));
+    segment.sync_all().expect("sync input");
+
+    assert!(matches!(
+        salvage_truncated_segment(&input, &bundle, DEFAULT_MAX_EVENT_BYTES),
+        Err(Error::SegmentNotTruncated)
+    ));
+    assert!(!bundle.exists());
 }

--- a/docs/archive_recovery.md
+++ b/docs/archive_recovery.md
@@ -1,0 +1,97 @@
+# Archive recovery operations
+
+This runbook covers two explicit repair paths. Neither path edits an original
+notepack source or an existing Parquet object.
+
+## Terminally truncated notepack source
+
+Use this only when the normal campaign reports `TruncatedFrame`. Arbitrary
+decoding failures and oversized frames are not terminal-truncation cases.
+
+1. Retain the exact source object in a recovery directory and record its size
+   and SHA-256.
+2. Create an immutable salvage bundle:
+
+   ```bash
+   pensieve-notepack-salvage \
+     segment-000001151.notepack \
+     segment-000001151-salvage
+   ```
+
+   The destination is atomically created and contains:
+
+   - `salvaged.notepack`: every structurally complete frame, byte for byte;
+   - `truncated-tail.bin`: the incomplete frame prefix and available payload
+     bytes after decompression; and
+   - `report.json`: canonical content-addressed source, frame-accounting, and
+     checksum evidence.
+
+   A complete input is rejected. Complete frames that fail event validation
+   remain in `salvaged.notepack`; the normal campaign will quarantine them.
+3. Run `salvaged.notepack` through `pensieve-parquet-campaign` with a separate
+   repair inventory and the canonical object-store prefix. Export its
+   active-raw fragment with `pensieve-lake-catalog export`.
+4. Bind the failed original source, salvage evidence, and published repair:
+
+   ```bash
+   pensieve-source-manifest build-exception-ledger \
+     --manifest historical-source-manifest.json \
+     --salvage-report segment-000001151-salvage/report.json \
+     --repair-fragment segment-000001151-repair-fragment.json \
+     --output historical-source-exceptions.json
+   ```
+
+   This is fail-closed: source name/size, original checksum, complete-frame
+   count, reject count, salvaged checksum, repair work-unit identity, and
+   active repair coverage must reconcile. The ledger is no-clobber evidence.
+5. Supply both artifacts to the final completion audit:
+
+   ```bash
+   pensieve-source-manifest audit \
+     --manifest historical-source-manifest.json \
+     --inventory campaign.sqlite \
+     --exceptions historical-source-exceptions.json \
+     --repair-fragment segment-000001151-repair-fragment.json \
+     --output historical-completion-audit.json
+   ```
+
+The audit counts the source as resolved, not normally published. It keeps the
+failed original inventory row and verifies the repair fragment on every run.
+
+## Exact-ID relay recovery
+
+`recover-events` accepts a preserved target ID file and an operator-supplied
+relay list. It validates every existing output row before resuming, accepts
+only target IDs with valid IDs and signatures, fsyncs appended recovery data,
+and atomically replaces the current missing-ID snapshot.
+
+For recurring segment-7703 rounds, create a new retained round directory. Use
+the previous round's missing-ID snapshot as this round's target file and an
+expanded relay list:
+
+```bash
+recover-events \
+  round-N/target-event-ids.hex \
+  round-N/recovered-events.jsonl \
+  round-N/missing-event-ids.hex \
+  --relay-file round-N/relays.txt \
+  --journal round-N/recovery-journal.jsonl \
+  --batch-sizes 20,1 \
+  --concurrency 4 \
+  --request-timeout-secs 12
+```
+
+After each round:
+
+1. preserve target, recovered, missing, relay-list, and journal checksums;
+2. prove recovered and missing IDs are unique/disjoint and their union is the
+   round target;
+3. validate recovered JSONL through the normal ingest path with an isolated
+   dedupe database;
+4. publish only newly recovered events as a new immutable repair work unit;
+5. index that delta into the still-running ClickHouse shadow; and
+6. merge the repair fragment into a new unified active-raw snapshot.
+
+An event body cannot be reconstructed from its ID. A round that recovers zero
+events is a valid result; its remaining IDs stay explicit and can be retried
+later against a materially different relay set.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -525,6 +525,15 @@ joins the frozen source universe to the complete campaign inventory and active
 raw catalog view, then reports missing, failed, in-progress, unexpected, and
 event-accounting defects.
 
+Recovery checkpoint (2026-07-28): terminally truncated source files now have a
+fail-closed salvage path that atomically retains every complete frame, the
+exact incomplete terminal bytes, and a content-addressed evidence report.
+Published salvage work is bound to the failed original through an immutable
+exception ledger, so campaign completion can account for a damaged input
+without relabeling it as a normal success. Exact-ID relay recovery is also a
+first-class resumable binary with operator-supplied relay sets, validated
+append-only output, durable batch journaling, and atomic missing-ID snapshots.
+
 #### P2d — Converge and verify
 
 - [x] Build a deterministic **unified active-raw snapshot catalog** across the

--- a/docs/segment_7703_recovery.md
+++ b/docs/segment_7703_recovery.md
@@ -1,6 +1,6 @@
 # Segment 7703 recovery record
 
-*Status: repair published; recovery complete with a known unavailable-event gap*
+*Status: initial repair published; recurring exact-ID recovery remains open*
 
 This is the durable audit record for the first production live-shadow segment,
 `segment-000007703.notepack.gz`.
@@ -111,6 +111,10 @@ The full recovery evidence archive is retained on production at
 - the catalog archive expands to the three source fragments and the exact
   unified snapshot JSON.
 
-The 17,139 missing IDs remain an explicit known gap. An event body cannot be
-reconstructed from an ID alone; these unavailable events are retained in the
-audit instead of being fabricated or silently counted as recovered.
+The 17,139 IDs not found in the initial relay rounds remain an explicit known
+gap. They are currently unrecovered, not classified as permanently
+unavailable. The retained missing-ID set can be used for recurring recovery
+against materially broader relay sets with the first-class `recover-events`
+tool described in [`archive_recovery.md`](archive_recovery.md). An event body
+cannot be reconstructed from an ID alone, so every still-missing event remains
+in the audit instead of being fabricated or silently counted as recovered.

--- a/justfile
+++ b/justfile
@@ -53,6 +53,14 @@ parquet-campaign *ARGS:
 source-manifest *ARGS:
     cargo run -p pensieve-lake --bin pensieve-source-manifest -- {{ARGS}}
 
+# Recover exact event IDs from an operator-supplied relay set.
+recover-events *ARGS:
+    cargo run -p pensieve-ingest --bin recover-events -- {{ARGS}}
+
+# Preserve the complete prefix and terminal evidence of a truncated notepack.
+salvage-notepack *ARGS:
+    cargo run -p pensieve-parquet --bin pensieve-notepack-salvage -- {{ARGS}}
+
 # Export, merge, or verify deterministic active-file lake catalogs.
 lake-catalog *ARGS:
     cargo run -p pensieve-lake --bin pensieve-lake-catalog -- {{ARGS}}

--- a/ops/RUNBOOK.md
+++ b/ops/RUNBOOK.md
@@ -173,6 +173,12 @@ pass has stopped normally.
    every named retryable failure or damaged-source exception rather than
    editing the report or an existing Parquet object.
 
+Damaged-source salvage and recurring exact-ID relay recovery follow
+[`docs/archive_recovery.md`](../docs/archive_recovery.md). Keep repairs in
+separate inventories, publish them under the same canonical object prefix, and
+merge their active fragments into the unified snapshot. Never delete the
+failed historical inventory row to make the completion report green.
+
 ## One-time cutover (ops/ move + secrets → /etc)
 
 The move of compose/systemd paths and secrets to `/etc` must happen in lockstep with


### PR DESCRIPTION
## Summary

- salvage only terminally truncated notepack inputs into an atomic evidence bundle containing every complete frame, the exact incomplete tail, and a content-addressed report
- bind a failed original source to a published salvage repair through a no-clobber exception ledger used by the historical completion audit
- promote exact-ID relay recovery into a resumable first-class binary with operator-supplied relay sets, strict output validation, durable journaling, and atomic missing-ID snapshots
- document the damaged-source and recurring segment-7703 recovery procedures

## Real segment 1151 result

The conversion VM retained and processed the actual 201,229,929-byte source. It contains 160,300 valid complete frames followed by only a four-byte length prefix declaring a missing 31,827-byte payload. The complete prefix was published through an isolated repair inventory as one strictly validated 160,300-row Parquet object. The exception ledger now removes segment 1151 from the live completion-audit problem set while preserving the failed original row. The main campaign remained active.

## Stack

This draft targets `codex/bounded-campaign-manifest` and should merge after #36. After #36 lands, retarget this PR to `master`.

## Validation

- `just precommit`
- focused salvage, exception-accounting, and relay-recovery tests
- real source download/checksum and terminal-tail evidence capture
- real isolated S3 repair publication and strict Parquet validation
- real exception-ledger build and progress audit against the live campaign inventory