### PR TITLE
Add first DuckDB/Postgres analytics slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -113,6 +113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,20 +134,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
+dependencies = [
+ "arrow-arith",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast",
+ "arrow-data 58.4.0",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-array"
 version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
  "chrono",
  "half",
  "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
  "num-traits",
 ]
 
@@ -155,13 +226,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ord",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer 58.4.0",
+ "arrow-schema 58.4.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-data"
 version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 59.1.0",
+ "arrow-schema 59.1.0",
  "half",
  "num-integer",
  "num-traits",
@@ -173,12 +279,47 @@ version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
  "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -189,16 +330,47 @@ checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
 
 [[package]]
 name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
 version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -210,6 +382,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -241,6 +424,15 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -372,14 +564,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "lru 0.12.5",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -466,13 +658,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -503,10 +695,10 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -792,7 +984,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -845,6 +1037,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +1085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1121,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
@@ -965,7 +1178,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -975,7 +1199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1001,7 +1225,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1054,7 +1278,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1099,7 +1323,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1112,6 +1336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1352,17 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1137,6 +1378,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1203,6 +1450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,7 +1480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rand 0.9.2",
  "regex",
  "rustversion",
@@ -1262,6 +1518,28 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1303,6 +1581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1598,15 @@ dependencies = [
  "dispatch2",
  "nix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1331,7 +1627,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1345,14 +1641,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1375,7 +1694,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1383,6 +1702,23 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "duckdb"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libduckdb-sys",
+ "num-integer",
+ "strum",
+]
 
 [[package]]
 name = "dunce"
@@ -1417,7 +1753,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
  "der",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1476,6 +1812,12 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -1512,6 +1854,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1670,7 +2023,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1722,7 +2075,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1735,9 +2088,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1871,6 +2236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,7 +2293,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1988,6 +2371,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2354,11 +2746,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2380,10 +2773,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "lexical-core"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.10505.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb514dab5e271e849235c1cb98bd65a2ae107fbd619a6740219319c54a71d95"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "serde",
+ "serde_json",
+ "tar",
+ "ureq",
+ "vcpkg",
+ "zip",
+]
 
 [[package]]
 name = "libloading"
@@ -2400,6 +2867,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "librocksdb-sys"
@@ -2428,6 +2904,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2922,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2538,7 +3029,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2548,7 +3039,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2642,7 +3143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2738,7 +3239,7 @@ dependencies = [
  "bip39",
  "bitcoin_hashes",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "getrandom 0.2.16",
  "hex",
@@ -2889,10 +3390,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -2935,7 +3454,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2970,7 +3489,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3009,12 +3528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5302d4da74d6596a1f11f9928767995b53bca657cbeea1e4e8c5074f8a1157dd"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
  "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
  "base64",
  "bytes",
  "chrono",
@@ -3052,8 +3571,29 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "pensieve-analytics"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "duckdb",
+ "hex",
+ "nostr",
+ "pensieve-core",
+ "pensieve-lake",
+ "pensieve-parquet",
+ "postgres",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3124,7 +3664,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -3134,8 +3674,8 @@ dependencies = [
 name = "pensieve-parquet"
 version = "0.1.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 59.1.0",
+ "arrow-schema 59.1.0",
  "bytes",
  "clap",
  "flate2",
@@ -3231,6 +3771,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,7 +3855,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3306,6 +3865,52 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "postgres"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.2",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3338,7 +3943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3358,7 +3963,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "version_check",
 ]
 
@@ -3388,7 +3993,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.111",
  "tempfile",
 ]
 
@@ -3402,7 +4007,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3451,7 +4056,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -3533,6 +4138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3551,6 +4162,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3590,6 +4212,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -3721,7 +4349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -3771,9 +4399,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.10.0",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -3795,6 +4423,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -3802,7 +4443,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3825,6 +4466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3940,7 +4582,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3961,7 +4603,7 @@ checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4073,7 +4715,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4084,7 +4726,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4130,8 +4772,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4141,8 +4783,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4175,7 +4828,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4285,10 +4938,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "subtle"
@@ -4318,6 +5003,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4334,7 +5030,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4342,6 +5038,17 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -4352,7 +5059,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -4382,7 +5089,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4393,7 +5100,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4520,7 +5227,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4531,6 +5238,32 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.2",
+ "socket2 0.6.1",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -4662,7 +5395,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4759,9 +5492,9 @@ checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -4815,10 +5548,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "universal-hash"
@@ -4826,7 +5571,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -4835,6 +5580,34 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -4886,6 +5659,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4950,6 +5729,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4959,10 +5747,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.106"
+name = "wasite"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4973,22 +5770,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4996,31 +5790,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5059,6 +5853,19 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"
@@ -5103,7 +5910,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5114,7 +5921,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5310,6 +6117,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.2",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,7 +6163,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -5367,7 +6184,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5387,7 +6204,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -5427,7 +6244,39 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,7 @@ ctrlc = { version = "3.4", features = ["termination"] }
 
 # SQLite
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+# Lakehouse analytics
+duckdb = { version = "1.10505.0", features = ["bundled", "parquet"] }
+postgres = { version = "0.19.14", features = ["with-chrono-0_4", "with-serde_json-1"] }

--- a/crates/pensieve-analytics/Cargo.toml
+++ b/crates/pensieve-analytics/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "pensieve-analytics"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file.workspace = true
+authors.workspace = true
+description = "DuckDB-to-Postgres analytics builder for Pensieve"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true
+clap = { version = "4.4", features = ["derive", "env"] }
+duckdb.workspace = true
+hex.workspace = true
+pensieve-core = { path = "../pensieve-core" }
+pensieve-lake = { path = "../pensieve-lake" }
+postgres.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+nostr.workspace = true
+pensieve-parquet = { path = "../pensieve-parquet" }
+tempfile = "3"

--- a/crates/pensieve-analytics/src/build.rs
+++ b/crates/pensieve-analytics/src/build.rs
@@ -453,6 +453,9 @@ fn scalar_u64(connection: &Connection, sql: &str) -> Result<u64> {
         .ok_or_else(|| Error::Validation(format!("query returned no scalar row: {sql}")))
 }
 
+// DuckDB does not accept bind parameters in `CREATE SECRET` options or in a
+// `read_parquet` file-list literal. Those values come from the operator-selected
+// catalog and CLI configuration, so quote and escape them in one place.
 fn sql_string(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }

--- a/crates/pensieve-analytics/src/build.rs
+++ b/crates/pensieve-analytics/src/build.rs
@@ -1,0 +1,458 @@
+//! Exact Slice A computation in a persistent DuckDB work database.
+
+use std::path::Path;
+
+use duckdb::{Connection, OptionalExt, params};
+use pensieve_core::NOSTR_GENESIS_TIMESTAMP;
+use serde::Serialize;
+
+use crate::{Error, ResolvedSnapshot, Result};
+
+/// Version of the SQL semantics materialized by this crate.
+pub const QUERY_VERSION: &str = "slice-a-v1";
+const API_TIMESTAMP_MAX: u64 = u32::MAX as u64;
+const SEVEN_DAYS_SECS: u64 = 7 * 24 * 60 * 60;
+const THIRTY_DAYS_SECS: u64 = 30 * 24 * 60 * 60;
+const HOURS_PER_SEVEN_DAYS: f64 = 168.0;
+
+/// Reproducible inputs to one full analytics build.
+#[derive(Clone, Debug)]
+pub struct BuildConfig {
+    /// Fixed upper event-time boundary used by rolling/non-future metrics.
+    pub as_of_epoch: u64,
+    /// Operator/build identity recorded with the run.
+    pub code_version: String,
+    /// AWS region used by DuckDB's S3 credential-chain secret.
+    pub s3_region: String,
+    /// Use S3 path-style addressing instead of virtual-host addressing.
+    pub s3_force_path_style: bool,
+}
+
+/// One-row overview product.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Overview {
+    /// Logical events after cross-file event-ID deduplication.
+    pub total_events: u64,
+    /// Logical events in the API-representable unsigned timestamp domain.
+    pub api_representable_events: u64,
+    /// Earliest representable event timestamp, clamped to Nostr genesis.
+    pub earliest_event: u32,
+    /// Latest event timestamp no later than `as_of`.
+    pub latest_event: u32,
+    /// Exact events in the inclusive rolling seven-day interval.
+    pub events_7d: u64,
+    /// Seven-day count divided by exactly 168 hours.
+    pub events_per_hour_7d: f64,
+    /// Distinct kinds in the rolling 30-day interval.
+    pub kinds_30d: u64,
+}
+
+/// One UTC date event-count row.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventDaily {
+    /// ISO-8601 UTC date.
+    pub day: String,
+    /// Exact logical events on the date.
+    pub event_count: u64,
+}
+
+/// One UTC date and event-kind count row.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventDailyKind {
+    /// ISO-8601 UTC date.
+    pub day: String,
+    /// Unsigned Nostr event kind.
+    pub kind: u16,
+    /// Exact logical events for the date and kind.
+    pub event_count: u64,
+}
+
+/// One all-time event-kind count row.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KindAllTime {
+    /// Unsigned Nostr event kind.
+    pub kind: u16,
+    /// Exact logical events of this kind.
+    pub event_count: u64,
+}
+
+/// Reconciled counts describing materialized DuckDB products.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct BuildSummary {
+    /// Physical rows asserted by the immutable input catalog.
+    pub physical_rows: u64,
+    /// Logical rows after event-ID deduplication.
+    pub logical_events: u64,
+    /// Physical duplicate rows removed.
+    pub duplicate_rows: u64,
+    /// Logical rows represented in UTC daily products.
+    pub api_representable_events: u64,
+    /// Rows in the all-kind daily relation.
+    pub event_daily_rows: u64,
+    /// Rows in the daily-kind relation.
+    pub event_daily_kind_rows: u64,
+    /// Rows in the all-time kind relation.
+    pub kind_all_time_rows: u64,
+}
+
+/// One completed DuckDB build, ready for Postgres publication.
+pub struct AnalyticsBuild {
+    connection: Connection,
+    /// Validated catalog and exact object locations used by the build.
+    pub snapshot: ResolvedSnapshot,
+    /// Fixed build configuration.
+    pub config: BuildConfig,
+    /// Reconciled materialized relation counts.
+    pub summary: BuildSummary,
+}
+
+impl AnalyticsBuild {
+    /// Build all Slice A products in `work_database`.
+    ///
+    /// The work database is persistent so large scans can spill out of core and
+    /// the completed products survive a transient Postgres publication failure.
+    pub fn create(
+        work_database: impl AsRef<Path>,
+        snapshot: ResolvedSnapshot,
+        config: BuildConfig,
+    ) -> Result<Self> {
+        if config.as_of_epoch > API_TIMESTAMP_MAX {
+            return Err(Error::Validation(format!(
+                "as_of {} exceeds the V1 API timestamp maximum {}",
+                config.as_of_epoch, API_TIMESTAMP_MAX
+            )));
+        }
+
+        let connection = Connection::open(work_database)?;
+        connection.execute_batch(
+            "
+            SET TimeZone = 'UTC';
+            SET preserve_insertion_order = false;
+            DROP TABLE IF EXISTS rollup_overview;
+            DROP TABLE IF EXISTS rollup_event_daily;
+            DROP TABLE IF EXISTS rollup_event_daily_kind;
+            DROP TABLE IF EXISTS rollup_kind_all_time;
+            DROP TABLE IF EXISTS canonical_events;
+            ",
+        )?;
+        configure_remote_access(&connection, &snapshot, &config)?;
+        materialize_canonical_events(&connection, &snapshot)?;
+        materialize_rollups(&connection, config.as_of_epoch)?;
+        let summary = validate_rollups(&connection, &snapshot)?;
+
+        Ok(Self {
+            connection,
+            snapshot,
+            config,
+            summary,
+        })
+    }
+
+    /// Read the one-row overview product.
+    pub fn overview(&self) -> Result<Overview> {
+        self.connection
+            .query_row(
+                "
+                SELECT
+                    total_events,
+                    api_representable_events,
+                    earliest_event,
+                    latest_event,
+                    events_7d,
+                    events_per_hour_7d,
+                    kinds_30d
+                FROM rollup_overview
+                ",
+                [],
+                |row| {
+                    Ok(Overview {
+                        total_events: row.get(0)?,
+                        api_representable_events: row.get(1)?,
+                        earliest_event: row.get(2)?,
+                        latest_event: row.get(3)?,
+                        events_7d: row.get(4)?,
+                        events_per_hour_7d: row.get(5)?,
+                        kinds_30d: row.get(6)?,
+                    })
+                },
+            )
+            .map_err(Error::from)
+    }
+
+    /// Visit daily event rows in stable ascending key order.
+    pub fn for_each_event_daily(
+        &self,
+        mut visit: impl FnMut(EventDaily) -> Result<()>,
+    ) -> Result<()> {
+        let mut statement = self.connection.prepare(
+            "SELECT CAST(day AS VARCHAR), event_count FROM rollup_event_daily ORDER BY day",
+        )?;
+        let mut rows = statement.query([])?;
+        while let Some(row) = rows.next()? {
+            visit(EventDaily {
+                day: row.get(0)?,
+                event_count: row.get(1)?,
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Visit daily-kind rows in stable ascending key order.
+    pub fn for_each_event_daily_kind(
+        &self,
+        mut visit: impl FnMut(EventDailyKind) -> Result<()>,
+    ) -> Result<()> {
+        let mut statement = self.connection.prepare(
+            "
+            SELECT CAST(day AS VARCHAR), kind, event_count
+            FROM rollup_event_daily_kind
+            ORDER BY day, kind
+            ",
+        )?;
+        let mut rows = statement.query([])?;
+        while let Some(row) = rows.next()? {
+            visit(EventDailyKind {
+                day: row.get(0)?,
+                kind: row.get(1)?,
+                event_count: row.get(2)?,
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Visit all-time kind rows in stable ascending key order.
+    pub fn for_each_kind_all_time(
+        &self,
+        mut visit: impl FnMut(KindAllTime) -> Result<()>,
+    ) -> Result<()> {
+        let mut statement = self
+            .connection
+            .prepare("SELECT kind, event_count FROM rollup_kind_all_time ORDER BY kind")?;
+        let mut rows = statement.query([])?;
+        while let Some(row) = rows.next()? {
+            visit(KindAllTime {
+                kind: row.get(0)?,
+                event_count: row.get(1)?,
+            })?;
+        }
+        Ok(())
+    }
+}
+
+fn configure_remote_access(
+    connection: &Connection,
+    snapshot: &ResolvedSnapshot,
+    config: &BuildConfig,
+) -> Result<()> {
+    let Some(endpoint) = snapshot.s3_endpoint.as_deref() else {
+        return Ok(());
+    };
+    connection.execute_batch("INSTALL httpfs; LOAD httpfs; INSTALL aws; LOAD aws;")?;
+
+    let url_style = if config.s3_force_path_style {
+        "path"
+    } else {
+        "vhost"
+    };
+    let sql = format!(
+        "
+        CREATE OR REPLACE SECRET pensieve_analytics_s3 (
+            TYPE s3,
+            PROVIDER credential_chain,
+            CHAIN 'env',
+            REGION {},
+            ENDPOINT {},
+            URL_STYLE {}
+        )
+        ",
+        sql_string(&config.s3_region),
+        sql_string(endpoint),
+        sql_string(url_style),
+    );
+    connection.execute_batch(&sql)?;
+    Ok(())
+}
+
+fn materialize_canonical_events(
+    connection: &Connection,
+    snapshot: &ResolvedSnapshot,
+) -> Result<()> {
+    if snapshot.locations.is_empty() {
+        connection.execute_batch(
+            "
+            CREATE TABLE canonical_events (
+                id BLOB NOT NULL,
+                created_at UBIGINT NOT NULL,
+                kind USMALLINT NOT NULL
+            );
+            ",
+        )?;
+        return Ok(());
+    }
+
+    let paths = snapshot
+        .locations
+        .iter()
+        .map(|location| sql_string(&location.duckdb_path()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "
+        CREATE TABLE canonical_events AS
+        SELECT id, created_at, kind
+        FROM (
+            SELECT
+                id,
+                created_at,
+                kind,
+                row_number() OVER (PARTITION BY id ORDER BY sig) AS canonical_rank
+            FROM read_parquet([{paths}], union_by_name = false)
+        )
+        WHERE canonical_rank = 1;
+        "
+    );
+    connection.execute_batch(&sql)?;
+    Ok(())
+}
+
+fn materialize_rollups(connection: &Connection, as_of: u64) -> Result<()> {
+    let seven_day_start = as_of.saturating_sub(SEVEN_DAYS_SECS);
+    let thirty_day_start = as_of.saturating_sub(THIRTY_DAYS_SECS);
+    connection.execute(
+        "
+        CREATE TABLE rollup_overview AS
+        SELECT
+            count(*)::UBIGINT AS total_events,
+            count(*) FILTER (WHERE created_at <= ?)::UBIGINT
+                AS api_representable_events,
+            greatest(
+                coalesce(min(created_at) FILTER (WHERE created_at <= ?), 0),
+                ?
+            )::UINTEGER AS earliest_event,
+            coalesce(
+                max(created_at) FILTER (WHERE created_at <= ?),
+                0
+            )::UINTEGER AS latest_event,
+            count(*) FILTER (
+                WHERE created_at >= ? AND created_at <= ?
+            )::UBIGINT AS events_7d,
+            (
+                count(*) FILTER (
+                    WHERE created_at >= ? AND created_at <= ?
+                )::DOUBLE / ?
+            ) AS events_per_hour_7d,
+            count(DISTINCT kind) FILTER (
+                WHERE created_at >= ? AND created_at <= ?
+            )::UBIGINT AS kinds_30d
+        FROM canonical_events
+        ",
+        params![
+            API_TIMESTAMP_MAX,
+            API_TIMESTAMP_MAX,
+            NOSTR_GENESIS_TIMESTAMP,
+            as_of,
+            seven_day_start,
+            as_of,
+            seven_day_start,
+            as_of,
+            HOURS_PER_SEVEN_DAYS,
+            thirty_day_start,
+            as_of,
+        ],
+    )?;
+    connection.execute(
+        "
+        CREATE TABLE rollup_event_daily AS
+        SELECT
+            DATE '1970-01-01' + CAST(created_at // 86400 AS INTEGER) AS day,
+            count(*)::UBIGINT AS event_count
+        FROM canonical_events
+        WHERE created_at <= ?
+        GROUP BY day
+        ORDER BY day
+        ",
+        params![API_TIMESTAMP_MAX],
+    )?;
+    connection.execute(
+        "
+        CREATE TABLE rollup_event_daily_kind AS
+        SELECT
+            DATE '1970-01-01' + CAST(created_at // 86400 AS INTEGER) AS day,
+            kind,
+            count(*)::UBIGINT AS event_count
+        FROM canonical_events
+        WHERE created_at <= ?
+        GROUP BY day, kind
+        ORDER BY day, kind
+        ",
+        params![API_TIMESTAMP_MAX],
+    )?;
+    connection.execute_batch(
+        "
+        CREATE TABLE rollup_kind_all_time AS
+        SELECT kind, count(*)::UBIGINT AS event_count
+        FROM canonical_events
+        GROUP BY kind
+        ORDER BY kind;
+        ",
+    )?;
+    Ok(())
+}
+
+fn validate_rollups(connection: &Connection, snapshot: &ResolvedSnapshot) -> Result<BuildSummary> {
+    let logical_events = scalar_u64(connection, "SELECT count(*) FROM canonical_events")?;
+    let physical_rows = snapshot.catalog.totals().physical_rows;
+    let duplicate_rows = physical_rows.checked_sub(logical_events).ok_or_else(|| {
+        Error::Validation(format!(
+            "catalog claims {physical_rows} physical rows but DuckDB produced {logical_events} logical rows"
+        ))
+    })?;
+    let api_representable_events = scalar_u64(
+        connection,
+        "SELECT api_representable_events FROM rollup_overview",
+    )?;
+    validate_sum(connection, "rollup_event_daily", api_representable_events)?;
+    validate_sum(
+        connection,
+        "rollup_event_daily_kind",
+        api_representable_events,
+    )?;
+    validate_sum(connection, "rollup_kind_all_time", logical_events)?;
+
+    Ok(BuildSummary {
+        physical_rows,
+        logical_events,
+        duplicate_rows,
+        api_representable_events,
+        event_daily_rows: scalar_u64(connection, "SELECT count(*) FROM rollup_event_daily")?,
+        event_daily_kind_rows: scalar_u64(
+            connection,
+            "SELECT count(*) FROM rollup_event_daily_kind",
+        )?,
+        kind_all_time_rows: scalar_u64(connection, "SELECT count(*) FROM rollup_kind_all_time")?,
+    })
+}
+
+fn validate_sum(connection: &Connection, table: &str, expected: u64) -> Result<()> {
+    let actual = scalar_u64(
+        connection,
+        &format!("SELECT coalesce(sum(event_count), 0)::UBIGINT FROM {table}"),
+    )?;
+    if actual != expected {
+        return Err(Error::Validation(format!(
+            "{table} sums to {actual}, expected {expected}"
+        )));
+    }
+    Ok(())
+}
+
+fn scalar_u64(connection: &Connection, sql: &str) -> Result<u64> {
+    connection
+        .query_row(sql, [], |row| row.get(0))
+        .optional()?
+        .ok_or_else(|| Error::Validation(format!("query returned no scalar row: {sql}")))
+}
+
+fn sql_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}

--- a/crates/pensieve-analytics/src/error.rs
+++ b/crates/pensieve-analytics/src/error.rs
@@ -1,0 +1,43 @@
+//! Error types for analytics construction and publication.
+
+use std::path::PathBuf;
+
+/// Analytics builder result.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Failures that prevent a complete analytics run from being published.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The active-file catalog is invalid or unreadable.
+    #[error("active-file catalog error: {0}")]
+    Catalog(#[from] pensieve_lake::Error),
+    /// DuckDB could not scan or aggregate the selected snapshot.
+    #[error("DuckDB error: {0}")]
+    DuckDb(#[from] duckdb::Error),
+    /// Postgres could not stage or atomically publish the run.
+    #[error("Postgres error: {0}")]
+    Postgres(#[from] postgres::Error),
+    /// A local object does not exist under the configured lake root.
+    #[error("catalog object is missing locally: {0}")]
+    MissingLocalObject(PathBuf),
+    /// The catalog's store identity cannot be converted to an S3 location.
+    #[error("unsupported store_id {0:?}; expected s3+https://<endpoint>/<bucket>")]
+    UnsupportedStoreId(String),
+    /// A numeric value does not fit the serving database's signed domain.
+    #[error("{field} value {value} exceeds the supported signed 64-bit domain")]
+    NumericOverflow {
+        /// Name of the overflowing field.
+        field: &'static str,
+        /// Original unsigned value.
+        value: u64,
+    },
+    /// The materialized rollups do not reconcile.
+    #[error("analytics validation failed: {0}")]
+    Validation(String),
+    /// A deterministic run already exists but is not the current run.
+    #[error("analytics run {0} was already published and cannot replace a newer current run")]
+    StalePublishedRun(String),
+    /// Writing streamed COPY data failed.
+    #[error("failed to stream Postgres COPY data: {0}")]
+    CopyIo(#[from] std::io::Error),
+}

--- a/crates/pensieve-analytics/src/input.rs
+++ b/crates/pensieve-analytics/src/input.rs
@@ -1,0 +1,120 @@
+//! Resolve immutable catalog object keys to DuckDB-readable locations.
+
+use std::path::{Path, PathBuf};
+
+use pensieve_lake::{ActiveRawSnapshot, read_catalog_snapshot};
+
+use crate::{Error, Result};
+
+/// One object location understood by DuckDB.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ObjectLocation {
+    /// A local file below an operator-provided immutable lake root.
+    Local(PathBuf),
+    /// An object read directly through DuckDB's S3 support.
+    S3(String),
+}
+
+impl ObjectLocation {
+    /// Return a URI/path suitable for `read_parquet`.
+    pub fn duckdb_path(&self) -> String {
+        match self {
+            Self::Local(path) => path.to_string_lossy().into_owned(),
+            Self::S3(uri) => uri.clone(),
+        }
+    }
+}
+
+/// A validated active-file snapshot plus resolved object locations.
+#[derive(Clone, Debug)]
+pub struct ResolvedSnapshot {
+    /// Validated immutable active-file snapshot.
+    pub catalog: ActiveRawSnapshot,
+    /// Locations in the same canonical order as `catalog.objects()`.
+    pub locations: Vec<ObjectLocation>,
+    /// S3 endpoint hostname when locations are remote.
+    pub s3_endpoint: Option<String>,
+    /// S3 bucket when locations are remote.
+    pub s3_bucket: Option<String>,
+}
+
+/// Read a canonical snapshot and resolve all of its object keys.
+///
+/// Supplying `local_object_root` is the deterministic test/offline mode. When
+/// it is absent, `store_id` must identify an S3-compatible HTTPS namespace.
+pub fn resolve_snapshot(
+    catalog_path: impl AsRef<Path>,
+    local_object_root: Option<&Path>,
+) -> Result<ResolvedSnapshot> {
+    let catalog = read_catalog_snapshot(catalog_path)?;
+    if let Some(root) = local_object_root {
+        let mut locations = Vec::with_capacity(catalog.objects().len());
+        for object in catalog.objects() {
+            let path = root.join(&object.object_key);
+            if !path.is_file() {
+                return Err(Error::MissingLocalObject(path));
+            }
+            locations.push(ObjectLocation::Local(path));
+        }
+        return Ok(ResolvedSnapshot {
+            catalog,
+            locations,
+            s3_endpoint: None,
+            s3_bucket: None,
+        });
+    }
+
+    let (endpoint, bucket) = parse_s3_store_id(catalog.store_id())?;
+    let locations = catalog
+        .objects()
+        .iter()
+        .map(|object| ObjectLocation::S3(format!("s3://{bucket}/{}", object.object_key)))
+        .collect();
+    Ok(ResolvedSnapshot {
+        catalog,
+        locations,
+        s3_endpoint: Some(endpoint),
+        s3_bucket: Some(bucket),
+    })
+}
+
+fn parse_s3_store_id(store_id: &str) -> Result<(String, String)> {
+    let namespace = store_id
+        .strip_prefix("s3+https://")
+        .ok_or_else(|| Error::UnsupportedStoreId(store_id.to_owned()))?;
+    let (endpoint, bucket) = namespace
+        .split_once('/')
+        .ok_or_else(|| Error::UnsupportedStoreId(store_id.to_owned()))?;
+    if endpoint.is_empty()
+        || bucket.is_empty()
+        || bucket.contains('/')
+        || endpoint.contains(['?', '#'])
+        || bucket.contains(['?', '#'])
+    {
+        return Err(Error::UnsupportedStoreId(store_id.to_owned()));
+    }
+    Ok((endpoint.to_owned(), bucket.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_s3_store_id;
+
+    #[test]
+    fn parses_full_s3_namespace_identity() {
+        assert_eq!(
+            parse_s3_store_id("s3+https://hel1.your-objectstorage.com/pensieve-parquet")
+                .expect("valid namespace"),
+            (
+                "hel1.your-objectstorage.com".to_owned(),
+                "pensieve-parquet".to_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_store_identity() {
+        assert!(parse_s3_store_id("pensieve-parquet").is_err());
+        assert!(parse_s3_store_id("s3+https://host/bucket/prefix").is_err());
+    }
+}

--- a/crates/pensieve-analytics/src/lib.rs
+++ b/crates/pensieve-analytics/src/lib.rs
@@ -1,0 +1,17 @@
+//! Rebuildable analytics products derived from canonical Parquet snapshots.
+//!
+//! DuckDB performs large object scans and exact aggregation. Postgres receives
+//! only small serving relations, all keyed by one immutable analytics run.
+
+mod build;
+mod error;
+mod input;
+mod publish;
+
+pub use build::{
+    AnalyticsBuild, BuildConfig, BuildSummary, EventDaily, EventDailyKind, KindAllTime, Overview,
+    QUERY_VERSION,
+};
+pub use error::{Error, Result};
+pub use input::{ObjectLocation, ResolvedSnapshot, resolve_snapshot};
+pub use publish::{PublishOutcome, publish};

--- a/crates/pensieve-analytics/src/main.rs
+++ b/crates/pensieve-analytics/src/main.rs
@@ -1,0 +1,139 @@
+//! Build and optionally publish the first lakehouse analytics slice.
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use pensieve_analytics::{AnalyticsBuild, BuildConfig, PublishOutcome, publish, resolve_snapshot};
+use postgres::{Client, NoTls};
+use serde::Serialize;
+
+#[derive(Debug, Parser)]
+#[command(about = "Build exact Slice A analytics from one active-file snapshot")]
+struct Args {
+    /// Canonically encoded active-raw snapshot JSON.
+    #[arg(long)]
+    catalog: PathBuf,
+    /// Persistent DuckDB work database used for scans and spill.
+    #[arg(long)]
+    work_database: PathBuf,
+    /// Resolve catalog keys below this local root instead of reading S3.
+    #[arg(long)]
+    local_object_root: Option<PathBuf>,
+    /// Fixed Unix timestamp for rolling metrics; defaults to process start.
+    #[arg(long)]
+    as_of: Option<u64>,
+    /// Build/commit identity stored in analytics run metadata.
+    #[arg(
+        long,
+        env = "PENSIEVE_ANALYTICS_CODE_VERSION",
+        default_value = concat!("pensieve-analytics/", env!("CARGO_PKG_VERSION"))
+    )]
+    code_version: String,
+    /// Postgres connection string. Omit to build and validate without publishing.
+    #[arg(long, env = "DATABASE_URL")]
+    postgres_url: Option<String>,
+    /// AWS region used by DuckDB's environment credential chain.
+    #[arg(long, env = "AWS_REGION", default_value = "us-east-1")]
+    s3_region: String,
+    /// Use path-style S3 addressing.
+    #[arg(long)]
+    s3_force_path_style: bool,
+}
+
+#[derive(Serialize)]
+struct Output<'a> {
+    snapshot_id: &'a str,
+    as_of_epoch: u64,
+    code_version: &'a str,
+    overview: pensieve_analytics::Overview,
+    build: &'a pensieve_analytics::BuildSummary,
+    publication: Option<PublicationOutput>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum PublicationOutput {
+    Published {
+        run_id: String,
+        previous_run_id: Option<String>,
+    },
+    AlreadyCurrent {
+        run_id: String,
+    },
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("analytics build failed: {error:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let args = Args::parse();
+    let started_at = Utc::now();
+    let as_of_epoch = args.as_of.unwrap_or_else(unix_now);
+    let snapshot = resolve_snapshot(&args.catalog, args.local_object_root.as_deref())
+        .context("resolve active-file snapshot")?;
+    let build = AnalyticsBuild::create(
+        &args.work_database,
+        snapshot,
+        BuildConfig {
+            as_of_epoch,
+            code_version: args.code_version,
+            s3_region: args.s3_region,
+            s3_force_path_style: args.s3_force_path_style,
+        },
+    )
+    .context("materialize and validate DuckDB rollups")?;
+    let completed_at = Utc::now();
+    let publication = args
+        .postgres_url
+        .as_deref()
+        .map(|url| publish_build(url, &build, started_at, completed_at))
+        .transpose()?;
+    let output = Output {
+        snapshot_id: &build.snapshot.catalog.snapshot_id,
+        as_of_epoch,
+        code_version: &build.config.code_version,
+        overview: build.overview()?,
+        build: &build.summary,
+        publication,
+    };
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn publish_build(
+    postgres_url: &str,
+    build: &AnalyticsBuild,
+    started_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+) -> Result<PublicationOutput> {
+    let mut client =
+        Client::connect(postgres_url, NoTls).context("connect to Postgres without TLS")?;
+    Ok(
+        match publish(&mut client, build, started_at, completed_at)? {
+            PublishOutcome::Published {
+                run_id,
+                previous_run_id,
+            } => PublicationOutput::Published {
+                run_id,
+                previous_run_id,
+            },
+            PublishOutcome::AlreadyCurrent { run_id } => {
+                PublicationOutput::AlreadyCurrent { run_id }
+            }
+        },
+    )
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock must be after Unix epoch")
+        .as_secs()
+}

--- a/crates/pensieve-analytics/src/publish.rs
+++ b/crates/pensieve-analytics/src/publish.rs
@@ -1,0 +1,304 @@
+//! Transactional Postgres publication for completed Slice A products.
+
+use std::io::Write;
+
+use chrono::{DateTime, Utc};
+use postgres::{Client, GenericClient};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::{AnalyticsBuild, Error, QUERY_VERSION, Result};
+
+const SCHEMA_SQL: &str = include_str!("../../../docs/postgres/001_analytics_slice_a.sql");
+const PUBLICATION_LOCK_ID: i64 = 8_056_718_693_194_101_224;
+
+/// Result of attempting to publish a deterministic run.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PublishOutcome {
+    /// A new run was staged, validated, and made current.
+    Published {
+        /// Deterministic analytics run identifier.
+        run_id: String,
+        /// Previously current run, if any.
+        previous_run_id: Option<String>,
+    },
+    /// The same run was already the complete current run.
+    AlreadyCurrent {
+        /// Deterministic analytics run identifier.
+        run_id: String,
+    },
+}
+
+#[derive(Serialize)]
+struct ValidationRecord {
+    event_daily_sum: u64,
+    event_daily_kind_sum: u64,
+    kind_all_time_sum: u64,
+    result: &'static str,
+}
+
+/// Publish one completed DuckDB build behind the Postgres current-run pointer.
+///
+/// Schema creation is idempotent. All run metadata, inputs, products, and the
+/// pointer change are committed in one transaction while holding a transaction
+/// advisory lock, so readers cannot observe a partial or mixed run.
+pub fn publish(
+    client: &mut Client,
+    build: &AnalyticsBuild,
+    started_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+) -> Result<PublishOutcome> {
+    client.batch_execute(SCHEMA_SQL)?;
+    let run_id = run_id(build);
+    let mut transaction = client.transaction()?;
+    transaction.query_one("SELECT pg_advisory_xact_lock($1)", &[&PUBLICATION_LOCK_ID])?;
+
+    let current_run_id = transaction
+        .query_opt(
+            "SELECT run_id FROM pensieve_analytics.current_run WHERE singleton = true FOR UPDATE",
+            &[],
+        )?
+        .map(|row| row.get::<_, String>(0));
+    if transaction
+        .query_opt(
+            "SELECT run_id FROM pensieve_analytics.runs WHERE run_id = $1",
+            &[&run_id],
+        )?
+        .is_some()
+    {
+        if current_run_id.as_deref() == Some(run_id.as_str()) {
+            transaction.commit()?;
+            return Ok(PublishOutcome::AlreadyCurrent { run_id });
+        }
+        return Err(Error::StalePublishedRun(run_id));
+    }
+
+    let overview = build.overview()?;
+    let validation = serde_json::to_value(ValidationRecord {
+        event_daily_sum: build.summary.api_representable_events,
+        event_daily_kind_sum: build.summary.api_representable_events,
+        kind_all_time_sum: build.summary.logical_events,
+        result: "passed",
+    })
+    .expect("serializing a fixed validation record cannot fail");
+    transaction.execute(
+        "
+        INSERT INTO pensieve_analytics.runs (
+            run_id,
+            snapshot_id,
+            previous_run_id,
+            run_kind,
+            query_version,
+            code_version,
+            as_of_epoch,
+            started_at,
+            completed_at,
+            published_at,
+            physical_rows,
+            logical_events,
+            duplicate_rows,
+            api_representable_events,
+            event_daily_rows,
+            event_daily_kind_rows,
+            kind_all_time_rows,
+            validation
+        )
+        VALUES (
+            $1, $2, $3, 'full_rebuild', $4, $5, $6, $7, $8, now(),
+            $9, $10, $11, $12, $13, $14, $15, $16
+        )
+        ",
+        &[
+            &run_id,
+            &build.snapshot.catalog.snapshot_id,
+            &current_run_id,
+            &QUERY_VERSION,
+            &build.config.code_version,
+            &to_i64("as_of_epoch", build.config.as_of_epoch)?,
+            &started_at,
+            &completed_at,
+            &to_i64("physical_rows", build.summary.physical_rows)?,
+            &to_i64("logical_events", build.summary.logical_events)?,
+            &to_i64("duplicate_rows", build.summary.duplicate_rows)?,
+            &to_i64(
+                "api_representable_events",
+                build.summary.api_representable_events,
+            )?,
+            &to_i64("event_daily_rows", build.summary.event_daily_rows)?,
+            &to_i64("event_daily_kind_rows", build.summary.event_daily_kind_rows)?,
+            &to_i64("kind_all_time_rows", build.summary.kind_all_time_rows)?,
+            &validation,
+        ],
+    )?;
+    insert_inputs(&mut transaction, &run_id, build)?;
+    transaction.execute(
+        "
+        INSERT INTO pensieve_analytics.overview (
+            run_id,
+            total_events,
+            api_representable_events,
+            earliest_event,
+            latest_event,
+            events_7d,
+            events_per_hour_7d,
+            kinds_30d
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        ",
+        &[
+            &run_id,
+            &to_i64("total_events", overview.total_events)?,
+            &to_i64(
+                "api_representable_events",
+                overview.api_representable_events,
+            )?,
+            &i64::from(overview.earliest_event),
+            &i64::from(overview.latest_event),
+            &to_i64("events_7d", overview.events_7d)?,
+            &overview.events_per_hour_7d,
+            &to_i64("kinds_30d", overview.kinds_30d)?,
+        ],
+    )?;
+
+    copy_event_daily(&mut transaction, &run_id, build)?;
+    copy_event_daily_kind(&mut transaction, &run_id, build)?;
+    copy_kind_all_time(&mut transaction, &run_id, build)?;
+
+    transaction.execute(
+        "
+        INSERT INTO pensieve_analytics.current_run (singleton, run_id)
+        VALUES (true, $1)
+        ON CONFLICT (singleton) DO UPDATE SET run_id = EXCLUDED.run_id
+        ",
+        &[&run_id],
+    )?;
+    transaction.commit()?;
+    Ok(PublishOutcome::Published {
+        run_id,
+        previous_run_id: current_run_id,
+    })
+}
+
+fn insert_inputs(
+    transaction: &mut impl GenericClient,
+    run_id: &str,
+    build: &AnalyticsBuild,
+) -> Result<()> {
+    let statement = transaction.prepare(
+        "
+        INSERT INTO pensieve_analytics.run_inputs (
+            run_id,
+            object_key,
+            work_unit_id,
+            sha256,
+            byte_size,
+            physical_rows
+        )
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ",
+    )?;
+    for object in build.snapshot.catalog.objects() {
+        transaction.execute(
+            &statement,
+            &[
+                &run_id,
+                &object.object_key,
+                &object.work_unit_id,
+                &object.sha256,
+                &to_i64("object byte_size", object.byte_size)?,
+                &to_i64("object row_count", object.row_count)?,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn copy_event_daily(
+    transaction: &mut impl GenericClient,
+    run_id: &str,
+    build: &AnalyticsBuild,
+) -> Result<()> {
+    let mut writer = transaction.copy_in(
+        "
+        COPY pensieve_analytics.event_daily (run_id, day, event_count)
+        FROM STDIN WITH (FORMAT csv)
+        ",
+    )?;
+    build.for_each_event_daily(|row| {
+        writeln!(writer, "{run_id},{},{}", row.day, row.event_count)?;
+        Ok(())
+    })?;
+    let inserted = writer.finish()?;
+    expect_copied("event_daily", inserted, build.summary.event_daily_rows)
+}
+
+fn copy_event_daily_kind(
+    transaction: &mut impl GenericClient,
+    run_id: &str,
+    build: &AnalyticsBuild,
+) -> Result<()> {
+    let mut writer = transaction.copy_in(
+        "
+        COPY pensieve_analytics.event_daily_kind (run_id, day, kind, event_count)
+        FROM STDIN WITH (FORMAT csv)
+        ",
+    )?;
+    build.for_each_event_daily_kind(|row| {
+        writeln!(
+            writer,
+            "{run_id},{},{},{}",
+            row.day, row.kind, row.event_count
+        )?;
+        Ok(())
+    })?;
+    let inserted = writer.finish()?;
+    expect_copied(
+        "event_daily_kind",
+        inserted,
+        build.summary.event_daily_kind_rows,
+    )
+}
+
+fn copy_kind_all_time(
+    transaction: &mut impl GenericClient,
+    run_id: &str,
+    build: &AnalyticsBuild,
+) -> Result<()> {
+    let mut writer = transaction.copy_in(
+        "
+        COPY pensieve_analytics.kind_all_time (run_id, kind, event_count)
+        FROM STDIN WITH (FORMAT csv)
+        ",
+    )?;
+    build.for_each_kind_all_time(|row| {
+        writeln!(writer, "{run_id},{},{}", row.kind, row.event_count)?;
+        Ok(())
+    })?;
+    let inserted = writer.finish()?;
+    expect_copied("kind_all_time", inserted, build.summary.kind_all_time_rows)
+}
+
+fn expect_copied(table: &str, actual: u64, expected: u64) -> Result<()> {
+    if actual != expected {
+        return Err(Error::Validation(format!(
+            "Postgres copied {actual} {table} rows, expected {expected}"
+        )));
+    }
+    Ok(())
+}
+
+fn run_id(build: &AnalyticsBuild) -> String {
+    let mut digest = Sha256::new();
+    digest.update(build.snapshot.catalog.snapshot_id.as_bytes());
+    digest.update([0]);
+    digest.update(build.config.as_of_epoch.to_be_bytes());
+    digest.update([0]);
+    digest.update(QUERY_VERSION.as_bytes());
+    digest.update([0]);
+    digest.update(build.config.code_version.as_bytes());
+    hex::encode(digest.finalize())
+}
+
+fn to_i64(field: &'static str, value: u64) -> Result<i64> {
+    i64::try_from(value).map_err(|_| Error::NumericOverflow { field, value })
+}

--- a/crates/pensieve-analytics/tests/slice_a.rs
+++ b/crates/pensieve-analytics/tests/slice_a.rs
@@ -1,0 +1,307 @@
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use nostr::{Event, EventBuilder, Keys, Kind, Timestamp};
+use pensieve_analytics::{AnalyticsBuild, BuildConfig, PublishOutcome, publish, resolve_snapshot};
+use pensieve_lake::{
+    ActiveRawFragment, Inventory, ObjectKind, ObjectRecord, ObjectState, WorkState,
+    WorkUnitRegistration, merge_active_raw_fragments, sha256_file, write_catalog_atomically,
+};
+use pensieve_parquet::write_events;
+
+const AS_OF: u64 = 1_700_000_000;
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    build: AnalyticsBuild,
+}
+
+fn test_keys() -> Keys {
+    Keys::parse("0000000000000000000000000000000000000000000000000000000000000001")
+        .expect("valid test secret key")
+}
+
+fn event(created_at: u64, kind: u16, content: &str) -> Event {
+    EventBuilder::new(Kind::from_u16(kind), content)
+        .custom_created_at(Timestamp::from(created_at))
+        .sign_with_keys(&test_keys())
+        .expect("test event should sign")
+}
+
+fn publish_object(inventory: &mut Inventory, lake_root: &Path, work_id: &str, events: &[Event]) {
+    let object_key = format!("nostr/v1/raw/{work_id}/part-00000.parquet");
+    let object_path = lake_root.join(&object_key);
+    std::fs::create_dir_all(object_path.parent().expect("object parent")).expect("create parent");
+    let summary = write_events(
+        File::create(&object_path).expect("create Parquet object"),
+        events.iter(),
+    )
+    .expect("write Parquet object");
+    let metadata = std::fs::metadata(&object_path).expect("object metadata");
+    let source_sha256 = "11".repeat(32);
+    inventory
+        .ensure_work_unit(&WorkUnitRegistration {
+            id: work_id,
+            source_path: &PathBuf::from(format!("/source/{work_id}.notepack.gz")),
+            source_bytes: 100,
+            source_sha256: &source_sha256,
+            target_uncompressed_bytes: 1_000,
+            max_event_bytes: 2_000,
+            object_prefix: "nostr/v1",
+            writer_version: "test-writer",
+        })
+        .expect("register work");
+    inventory
+        .transition_work(work_id, WorkState::Writing, None)
+        .expect("start work");
+    inventory
+        .record_validated_objects(
+            work_id,
+            events.len() as u64,
+            summary.output_rows as u64,
+            0,
+            &[ObjectRecord {
+                object_key: object_key.clone(),
+                work_unit_id: work_id.to_owned(),
+                part_number: 0,
+                kind: ObjectKind::Parquet,
+                state: ObjectState::Validated,
+                local_path: object_path.clone(),
+                byte_size: metadata.len(),
+                sha256: sha256_file(&object_path).expect("object checksum"),
+                writer_version: "test-writer".to_owned(),
+                row_count: summary.output_rows as u64,
+                min_created_at: events.iter().map(|event| event.created_at.as_secs()).min(),
+                max_created_at: events.iter().map(|event| event.created_at.as_secs()).max(),
+            }],
+        )
+        .expect("record validated object");
+    inventory
+        .transition_work(work_id, WorkState::Uploading, None)
+        .expect("start upload");
+    inventory
+        .mark_object_uploaded(&object_key)
+        .expect("mark uploaded");
+    inventory
+        .transition_work(work_id, WorkState::Uploaded, None)
+        .expect("finish upload");
+    inventory
+        .activate_work_unit(work_id)
+        .expect("activate object");
+}
+
+fn fixture() -> Fixture {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let lake_root = directory.path().join("lake");
+    let duplicate = event(AS_OF - 10, 1, "duplicate");
+    let lower_boundary = event(AS_OF - 7 * 24 * 60 * 60, 2, "lower");
+    let recent = event(AS_OF - 100_000, 2, "recent");
+    let pre_genesis = event(100, 3, "old");
+    let overflow = event(u64::from(u32::MAX) + 1, 4, "overflow");
+    let future = event(AS_OF + 100, 5, "future");
+
+    let mut inventory = Inventory::open_in_memory().expect("inventory");
+    publish_object(
+        &mut inventory,
+        &lake_root,
+        "first",
+        &[duplicate.clone(), lower_boundary, pre_genesis, overflow],
+    );
+    publish_object(
+        &mut inventory,
+        &lake_root,
+        "second",
+        &[duplicate, recent, future],
+    );
+    let fragment = ActiveRawFragment::export(
+        &mut inventory,
+        "test",
+        "s3+https://example.test/test-bucket",
+    )
+    .expect("export catalog");
+    let snapshot = merge_active_raw_fragments([fragment]).expect("merge snapshot");
+    let catalog_path = directory.path().join("snapshot.json");
+    write_catalog_atomically(&catalog_path, &snapshot).expect("write snapshot");
+
+    let resolved =
+        resolve_snapshot(&catalog_path, Some(&lake_root)).expect("resolve local snapshot");
+    let build = AnalyticsBuild::create(
+        directory.path().join("analytics.duckdb"),
+        resolved,
+        BuildConfig {
+            as_of_epoch: AS_OF,
+            code_version: "test".to_owned(),
+            s3_region: "test".to_owned(),
+            s3_force_path_style: false,
+        },
+    )
+    .expect("build analytics");
+    Fixture {
+        _directory: directory,
+        build,
+    }
+}
+
+#[test]
+fn slice_a_deduplicates_and_reconciles_exact_rollups() {
+    let fixture = fixture();
+    let build = fixture.build;
+
+    assert_eq!(build.summary.physical_rows, 7);
+    assert_eq!(build.summary.logical_events, 6);
+    assert_eq!(build.summary.duplicate_rows, 1);
+    assert_eq!(build.summary.api_representable_events, 5);
+    assert_eq!(build.summary.kind_all_time_rows, 5);
+
+    let overview = build.overview().expect("overview");
+    assert_eq!(overview.total_events, 6);
+    assert_eq!(overview.api_representable_events, 5);
+    assert_eq!(
+        overview.earliest_event,
+        pensieve_core::NOSTR_GENESIS_TIMESTAMP
+    );
+    assert_eq!(overview.latest_event, (AS_OF - 10) as u32);
+    assert_eq!(overview.events_7d, 3);
+    assert_eq!(overview.events_per_hour_7d, 3.0 / 168.0);
+    assert_eq!(overview.kinds_30d, 2);
+
+    let mut daily_sum = 0;
+    build
+        .for_each_event_daily(|row| {
+            daily_sum += row.event_count;
+            Ok(())
+        })
+        .expect("daily rows");
+    assert_eq!(daily_sum, 5);
+
+    let mut daily_kind_sum = 0;
+    build
+        .for_each_event_daily_kind(|row| {
+            daily_kind_sum += row.event_count;
+            Ok(())
+        })
+        .expect("daily kind rows");
+    assert_eq!(daily_kind_sum, 5);
+
+    let mut kind_counts = Vec::new();
+    build
+        .for_each_kind_all_time(|row| {
+            kind_counts.push((row.kind, row.event_count));
+            Ok(())
+        })
+        .expect("kind rows");
+    assert_eq!(kind_counts, vec![(1, 1), (2, 2), (3, 1), (4, 1), (5, 1)]);
+}
+
+#[test]
+fn slice_a_handles_a_snapshot_with_no_parquet_objects() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let mut inventory = Inventory::open_in_memory().expect("inventory");
+    let source_sha256 = "22".repeat(32);
+    inventory
+        .ensure_work_unit(&WorkUnitRegistration {
+            id: "empty",
+            source_path: Path::new("/source/empty.notepack.gz"),
+            source_bytes: 0,
+            source_sha256: &source_sha256,
+            target_uncompressed_bytes: 1_000,
+            max_event_bytes: 2_000,
+            object_prefix: "nostr/v1",
+            writer_version: "test-writer",
+        })
+        .expect("register empty work");
+    inventory
+        .transition_work("empty", WorkState::Writing, None)
+        .expect("start empty work");
+    inventory
+        .record_validated_objects("empty", 0, 0, 0, &[])
+        .expect("validate empty work");
+    inventory
+        .transition_work("empty", WorkState::Uploading, None)
+        .expect("start empty upload");
+    inventory
+        .transition_work("empty", WorkState::Uploaded, None)
+        .expect("finish empty upload");
+    inventory
+        .activate_work_unit("empty")
+        .expect("activate empty work");
+
+    let fragment = ActiveRawFragment::export(
+        &mut inventory,
+        "empty-test",
+        "s3+https://example.test/test-bucket",
+    )
+    .expect("export empty catalog");
+    let snapshot = merge_active_raw_fragments([fragment]).expect("merge empty snapshot");
+    let catalog_path = directory.path().join("empty-snapshot.json");
+    write_catalog_atomically(&catalog_path, &snapshot).expect("write empty snapshot");
+    let resolved = resolve_snapshot(&catalog_path, Some(directory.path()))
+        .expect("resolve empty local snapshot");
+    let build = AnalyticsBuild::create(
+        directory.path().join("empty.duckdb"),
+        resolved,
+        BuildConfig {
+            as_of_epoch: AS_OF,
+            code_version: "test".to_owned(),
+            s3_region: "test".to_owned(),
+            s3_force_path_style: false,
+        },
+    )
+    .expect("build empty analytics");
+
+    assert_eq!(build.summary.logical_events, 0);
+    assert_eq!(build.summary.event_daily_rows, 0);
+    let overview = build.overview().expect("empty overview");
+    assert_eq!(overview.total_events, 0);
+    assert_eq!(
+        overview.earliest_event,
+        pensieve_core::NOSTR_GENESIS_TIMESTAMP
+    );
+    assert_eq!(overview.latest_event, 0);
+    assert_eq!(overview.events_7d, 0);
+    assert_eq!(overview.kinds_30d, 0);
+}
+
+#[test]
+#[ignore = "requires a disposable Postgres database in PENSIEVE_TEST_POSTGRES_URL"]
+fn slice_a_publication_is_atomic_and_idempotent() {
+    let fixture = fixture();
+    let mut client = postgres::Client::connect(
+        &std::env::var("PENSIEVE_TEST_POSTGRES_URL")
+            .expect("PENSIEVE_TEST_POSTGRES_URL must be set"),
+        postgres::NoTls,
+    )
+    .expect("connect to disposable Postgres");
+    let started_at = chrono::Utc::now();
+    let completed_at = chrono::Utc::now();
+    let first =
+        publish(&mut client, &fixture.build, started_at, completed_at).expect("publish first run");
+    let run_id = match first {
+        PublishOutcome::Published { run_id, .. } => run_id,
+        PublishOutcome::AlreadyCurrent { .. } => panic!("database must begin empty"),
+    };
+    assert_eq!(
+        client
+            .query_one(
+                "SELECT run_id FROM pensieve_analytics.current_run_metadata",
+                &[],
+            )
+            .expect("read current run")
+            .get::<_, String>(0),
+        run_id
+    );
+    assert_eq!(
+        client
+            .query_one(
+                "SELECT total_events FROM pensieve_analytics.current_overview",
+                &[],
+            )
+            .expect("read current overview")
+            .get::<_, i64>(0),
+        6
+    );
+    assert_eq!(
+        publish(&mut client, &fixture.build, started_at, completed_at,).expect("retry current run"),
+        PublishOutcome::AlreadyCurrent { run_id }
+    );
+}

--- a/docs/analytics_endpoint_migration.md
+++ b/docs/analytics_endpoint_migration.md
@@ -1,0 +1,375 @@
+# Analytics Endpoint Migration Ledger
+
+*Status: draft design / P3 planning*
+*Last updated: 2026-07-28*
+
+This document freezes the current `pensieve-serve` analytics surface and maps
+each ClickHouse-backed endpoint to a proposed DuckDB computation and Postgres
+serving shape. It is the working contract for P3 of the lakehouse migration.
+
+The first objective is behavioral parity with the existing API. This document
+does not accept a Postgres schema, sketch implementation, batch frequency, or
+intentional behavior change. Those decisions must be supported by endpoint
+tests and old-versus-new evidence.
+
+## 1. Scope
+
+The current router exposes 30 GET routes:
+
+- 2 public service routes: `/health` and `/docs`;
+- 28 authenticated routes:
+  - 24 ClickHouse-backed analytics routes covered by this ledger;
+  - 3 relay-operational routes backed by the ingester's SQLite database; and
+  - 1 authenticated `/ping`.
+
+The old migration-plan count of 32 analytics endpoints is stale. The router in
+`crates/pensieve-serve/src/routes/mod.rs` is authoritative.
+
+The separate `pensieve-preview` event/profile lookup service is out of scope.
+The migration plan retires it. If random event lookup remains a product
+requirement, it needs a separate ID/address index and cannot be served from the
+small analytics rollups described here.
+
+## 2. Parity contract
+
+For each route, parity covers:
+
+1. accepted path and query parameters;
+2. defaults, maximums, validation, and error behavior;
+3. response JSON shape and ordering;
+4. the meaning and time domain of every metric;
+5. empty-data behavior;
+6. numeric exactness or an explicitly accepted approximation tolerance; and
+7. data freshness, HTTP cache policy, and server-side cache policy.
+
+The comparison domain is the canonical, ID-deduplicated event set representable
+by both systems. A ClickHouse result that counts duplicate physical rows,
+narrows an unsigned timestamp, includes malformed future dates, or reflects a
+known stale materialized view is evidence to classify, not automatically the
+desired lakehouse result.
+
+Every discrepancy must be assigned one of:
+
+- **bug** — the new implementation is wrong;
+- **expected approximation** — within the accepted per-metric tolerance;
+- **intentional correction** — a documented old-stack behavior is not carried
+  forward; or
+- **old-stack uncertainty** — the ClickHouse result cannot be treated as a
+  reliable oracle until separately resolved.
+
+## 3. Proposed execution boundary
+
+The API must not run object-storage DuckDB scans on the request path.
+
+```text
+active-file snapshot + new published work units
+                    │
+                    ▼
+        DuckDB analytics builder
+          derive → aggregate → validate
+                    │
+                    ▼
+        Postgres staging rows keyed by run_id
+                    │
+             atomic publication
+                    ▼
+       Postgres current serving relations
+                    │
+                    ▼
+        pensieve-serve + Grafana
+```
+
+DuckDB owns large scans and transformations. Postgres owns small indexed
+serving relations, run metadata, and atomic publication. Parquet remains the
+source of truth; all Postgres state is rebuildable.
+
+Each analytics run must record at least:
+
+- active-file snapshot ID;
+- previous successful run ID, when incremental;
+- input work-unit IDs and object checksums;
+- code/query version;
+- start, completion, and publication timestamps;
+- row counts and validation results per output relation; and
+- whether the run was a full rebuild, affected-period rebuild, or incremental
+  update.
+
+## 4. Shared semantic rules to freeze
+
+### 4.1 Event identity
+
+All lake computations count logical events by `id`, not physical Parquet rows.
+Raw active snapshots may contain an ID more than once. Until a snapshot is
+certified deduplicated, DuckDB must apply the canonical deterministic
+signature-selection rule before computing metrics.
+
+### 4.2 Time
+
+The archive preserves the full unsigned Nostr `created_at` domain. The current
+API and ClickHouse schema expose a narrower date/timestamp domain. The
+analytics builder must:
+
+- preserve the source value while reading;
+- explicitly select the API-representable domain for date rollups;
+- use UTC boundaries;
+- keep `since` inclusive and `until` exclusive where the current handler does;
+- record whether future timestamps are excluded for each metric; and
+- never infer ingestion order from `created_at`.
+
+Late-arriving events may change old date buckets. Incremental runs therefore
+must upsert or rebuild affected historical periods rather than update only
+"today."
+
+### 4.3 Active-user domain
+
+The current active-user and first-seen pipeline excludes kinds `445` and `1059`
+as throwaway-key activity. Profile and follows flags mean that a pubkey has a
+kind `0` or kind `3` event in the current derived ClickHouse state. The exact
+point-in-time versus ever-observed semantics of those flags must be preserved
+for parity tests before any correction is proposed.
+
+### 4.4 Distinct counts
+
+Additive counts and sums should be exact on the common ID-deduplicated domain.
+Distinct pubkey metrics require either exact state or mergeable sketches.
+
+The current plan names Apache DataSketches, but P3 must first prove:
+
+- compatible serialization across the selected DuckDB and Postgres/runtime
+  components;
+- stable union results across daily, weekly, and monthly windows;
+- acceptable error on representative Nostr cardinalities; and
+- repeatable deployment of any non-core database extension.
+
+Postgres does not need to understand sketches if the batch job can merge them
+and store final numeric results. Serialized sketch state should be stored only
+where arbitrary-window query-time composition justifies it.
+
+### 4.5 Atomic publication
+
+One API response must not combine rollups from different dataset snapshots.
+The builder writes a complete staged run, validates it, and then changes the
+single current-run reference transactionally. Readers either see the previous
+complete run or the next complete run.
+
+## 5. Current cache and freshness baseline
+
+There are two cache layers:
+
+- the in-process Moka response cache; and
+- HTTP `Cache-Control`/ETag policy.
+
+The default in-process TTL is 300 seconds. Explicit TTLs are 10 seconds
+(`REALTIME`), 600 seconds (`TIME_SERIES`), and 3600 seconds (`STABLE`), but most
+handlers call the default helper even where comments describe another TTL.
+HTTP policy separately uses 10 seconds for latest event, 300 seconds for event
+and pubkey totals, 600 seconds for selected time series, 3600 seconds for kinds
+total and earliest event, and 60 seconds otherwise.
+
+Consequences:
+
+- all five scalar fetch helpers convert ClickHouse query errors to zero, so the
+  granular scalar routes as well as `/stats` can return a successful false-zero
+  response;
+- `/stats/events/latest` is documented and HTTP-cached as near-real-time, but
+  currently uses the 300-second in-process default;
+- `/stats` is documented as one minute but uses the 300-second default;
+- active-user handlers are documented as ten minutes but use the 300-second
+  default; and
+- ClickHouse refresh schedules can be much slower than either response-cache
+  layer.
+
+Cache behavior is part of the migration audit, but accidental TTL mismatches do
+not have to become permanent. Any correction must be explicit and tested.
+
+## 6. Endpoint ledger
+
+Candidate Postgres names below communicate grain and purpose. They are not
+accepted DDL.
+
+### 6.1 Overview and scalar endpoints
+
+| Endpoint | Current contract and ClickHouse source | Proposed DuckDB computation | Candidate Postgres surface | Parity notes |
+|---|---|---|---|---|
+| `GET /api/v1/stats` | No params. Combines total events, pubkeys, kinds, earliest, and latest. Individual query errors are currently converted to zero by the internal fetch helpers. | Read the five published scalar values from one completed analytics run. | `analytics_overview` keyed by `run_id`. | Preserve JSON fields. Decide whether silent zero on a failed component is retained; preferred correction is to fail rather than publish false zeroes. |
+| `GET /api/v1/stats/events/total` | Returns `sum(rows)` for active `events_local` parts; described as approximate. | Count distinct canonical event IDs in the selected snapshot. Maintain incrementally only with duplicate-safe processing. | `analytics_overview.total_events`. | ClickHouse physical-row count may differ from the logical lake count. Treat this as an expected intentional correction after quantifying it. |
+| `GET /api/v1/stats/pubkeys/total` | Counts rows in `pubkey_first_seen_data`; first-seen ingestion excludes kinds `445` and `1059`. | Build one first-seen record per eligible pubkey and count it. | `pubkey_first_seen` plus `analytics_overview.total_pubkeys`. | Exact metric. Validate old aggregate-state duplication and invalid-date filtering separately. |
+| `GET /api/v1/stats/kinds/total` | Approximate `uniq(kind)` for `created_at >= now()-30d`; it does not explicitly exclude future timestamps. | Distinct kinds in the agreed rolling 30-day API domain. | Scalar derived from `event_daily_kind`. | Decide whether future events remain included. The likely correction is `created_at <= as_of`. |
+| `GET /api/v1/stats/events/earliest` | Minimum `created_at` over all rows, converted to `u32`, then clamped to Nostr genesis. | Minimum API-representable timestamp, then the same genesis clamp. | `analytics_overview.earliest_event`. | Exact on the shared timestamp domain. Add empty, pre-genesis, `u32::MAX`, and larger unsigned fixtures. |
+| `GET /api/v1/stats/events/latest` | Maximum `created_at <= now()`, converted to `u32`. Documented/HTTP TTL 10s; effective in-process TTL 300s. | Maintain a non-future event-time watermark from published events plus the selected live-delta source. | `analytics_overview.latest_event` or a dedicated hot watermark row. | Freshness is the key design decision. Parquet-only publication may lag the advertised endpoint by the live batch age. |
+
+### 6.2 Event and kind activity
+
+| Endpoint | Current contract and ClickHouse source | Proposed DuckDB computation | Candidate Postgres surface | Parity notes |
+|---|---|---|---|---|
+| `GET /api/v1/stats/events` | Optional `kind`, `since`, `until`, `days`, `group_by` (`day`, `week`, or `month`), and `limit` default 100/max 1000. Defaults to 30 days when no time filter is supplied. `days` overrides explicit dates. Ungrouped and kind-filtered queries scan `events_local`; unfiltered grouped queries use `daily_user_stats`. Future events are excluded only on the raw-event path. | Produce exact event counts and mergeable pubkey distinct state at daily+kind grain. Compose week/month and requested windows from daily rows. | `event_daily_kind`; optional all-kind rows or query-time sum/merge. | Preserve defaulting, inclusive `since`, exclusive `until`, descending order, dynamic JSON object/array shape, and group validation. The current unfiltered daily path uses `count()` of per-pubkey rows as unique pubkeys while other paths use approximate `uniq`. |
+| `GET /api/v1/stats/throughput` | Optional `kind`. Counts events with `created_at >= now()-7d`, divides by 168, and does not explicitly cap future timestamps. | Sum the rolling seven-day event buckets at a fixed `as_of`; include a small current-period delta if required. | Derived from `event_hourly_kind` or daily rows plus current hourly rows. | Exact additive metric. Decide future handling and whether "7 days" means an exact 168-hour interval or seven UTC dates. |
+| `GET /api/v1/kinds` | `limit` default 100/max 1000; `sort` accepts `count` or `kind`, invalid values are 400. Reads hourly `kinds_stats_mv`: all-time count, exact pubkeys, min/max timestamps. | Aggregate all-time by kind from deduplicated events; retain exact or agreed approximate distinct state. | `kind_all_time`. | Preserve sort and limits. Current refresh is hourly. |
+| `GET /api/v1/kinds/{kind}` | `u16` path. Returns all-time count, exact pubkeys, first/last, average content length, and 1d/7d/30d counts. Missing kind returns 404. | Combine all-time kind summary with rolling date/hour buckets. Read `content` only for kind summary builds that need its length. | `kind_all_time` plus `event_daily_kind`/`event_hourly_kind`. | Preserve 404 and response types. Decide future-date treatment for rolling and last-seen values. |
+| `GET /api/v1/kinds/{kind}/activity` | `group_by` accepts `day`, `week`, or `month` and defaults to day. `limit` default 30; max 365/52/120 by grain. All-time scan grouped by period with exact pubkeys. | Compose period rows from daily kind counts and distinct state. | `event_daily_kind`. | Exact counts; distinct tolerance to lock. No `since` parameter, so descending limit semantics must match. |
+| `GET /api/v1/stats/activity/hourly` | `days` default 7/max 90; optional kind. Groups events in the rolling window by UTC hour-of-day; returns counts, approximate pubkeys, and count/days. | Aggregate daily event facts at `(date, hour_of_day, kind)` and merge the selected dates/window. | `event_daily_hour_kind`. | Rolling `now()-N days` is not identical to N full UTC dates. Either store hourly event-time buckets or document a boundary correction. |
+| `GET /api/v1/stats/publishers` | `days` default 30; optional kind; `limit` default 100/max 1000. Groups the rolling raw event window by pubkey and returns count, distinct kinds, min/max event time. | Aggregate high-cardinality publisher facts over the requested window. | Candidate `publisher_daily_kind`, or a bounded-window top-K product with explicit supported windows. | This is not safely composable from daily top-K lists: a publisher outside every daily top-K can enter the multi-day top-K. This endpoint drives a potentially large serving relation and needs a measured design. |
+
+### 6.3 Active and new users
+
+All current active-user relations exclude kinds `445` and `1059`. Current
+profile/follows flags originate from kind `0` and `3` presence tables.
+
+| Endpoint | Current contract and ClickHouse source | Proposed DuckDB computation | Candidate Postgres surface | Parity notes |
+|---|---|---|---|---|
+| `GET /api/v1/stats/users/active` | No params. Returns the latest daily, weekly, and monthly rows from scheduled summary tables, bounded at Nostr genesis and the current period. | Read the current rows from the corresponding completed period products. | `active_users_period` with `grain` and `period_start`. | The three ClickHouse refresh schedules differ, so the current response can mix computation times. New publication should use one run, with freshness recorded per product. |
+| `GET /api/v1/stats/users/active/daily` | `limit` default 30/max 365; optional inclusive `since`. Fetches all daily summary rows, filters and truncates in Rust. | Build daily exact/sketched active pubkeys, profile/follows subsets, and exact event totals. | `active_users_period(grain='day')`. | Preserve descending order and genesis/current-date bounds. |
+| `GET /api/v1/stats/users/active/weekly` | Same response; `limit` default 12/max 52. Monday period starts. | Merge daily identity state into calendar weeks. | `active_users_period(grain='week')`. | Daily unique counts cannot be summed; merge identity/sketch state or compute weekly directly. |
+| `GET /api/v1/stats/users/active/monthly` | Same response; `limit` default 12/max 120. First-of-month starts. | Merge daily identity state into calendar months. | `active_users_period(grain='month')`. | Same non-additivity rule as weekly. |
+| `GET /api/v1/stats/users/new` | `group_by` accepts `day`, `week`, or `month` and defaults to day; `limit` default 30 with max 365/52/120; optional inclusive `since`. Sums scheduled daily first-seen counts. | Compute one eligible first-seen timestamp per pubkey, filter to the API date domain, then aggregate. | `pubkey_first_seen` and `new_users_daily`. | Exact and additive after each pubkey has one canonical first-seen row. Late historical events can move a pubkey to an older period, requiring subtraction from the former bucket. |
+| `GET /api/v1/stats/users/retention` | `cohort_size` accepts `week` or `month` and defaults to week; `limit` default 12/max 52; optional `cohort_start`. Reads daily-refreshed cohort/activity counts and calculates percentages in Rust. | Join eligible pubkey first-seen cohort to active periods and aggregate distinct pubkeys by `(cohort, activity_period)`. | `cohort_retention_period`. | Preserve period ordering and vector construction. Current query applies `.take(limit)` to an ascending `BTreeMap`, so it may return the oldest qualifying cohorts rather than the most recent `limit`; classify before migration. |
+
+### 6.4 Zaps and semantic event analytics
+
+| Endpoint | Current contract and ClickHouse source | Proposed DuckDB computation | Candidate Postgres surface | Parity notes |
+|---|---|---|---|---|
+| `GET /api/v1/stats/zaps` | `days` default 30 with no current maximum; optional `group_by` accepting `day`, `week`, or `month`; `limit` default 30/max 365. Uses parsed positive `zap_amounts_data`; returns exact count/sats, approximate senders/recipients, and average. | Reproduce the accepted bolt11/tag parsing rules, materialize one validated zap fact per event ID, and aggregate by day with sender/recipient distinct state. | `zap_daily` plus optional `zap_event_fact` outside the serving schema. | Parsing parity with migration 009 is the first gate. Preserve millisatoshi-to-satoshi truncation and grouped/aggregate JSON shapes. Decide a sane `days` maximum separately. |
+| `GET /api/v1/stats/zaps/histogram` | `days` default 30 with no maximum. Seventeen fixed inclusive sat buckets, positive amounts only; returns count/sats and percentages rounded to two decimals. | Bucket the same canonical zap facts, preferably at daily+bucket grain. | `zap_bucket_daily`. | Exact additive counts/sats; percentages derive at query time. Preserve boundaries, final `100K+` display maximum, truncation, and rounding. |
+| `GET /api/v1/stats/engagement` | `days` default 30 with no maximum. A reply is any kind `1` event containing an `e` tag; reactions are kind `7`; original notes are total kind `1` minus replies. | Derive `is_reply` from canonical nested tags and aggregate daily original/reply/reaction counts. | `engagement_daily`. | Exact counts. The definition does not distinguish root/reply markers or validate referenced IDs; preserve that simple rule for parity. |
+| `GET /api/v1/stats/longform` | Optional `days`; omission means all time. Kind `30023` only. Returns event count, approximate authors, byte length average/sum, and words estimated as total bytes/5. | Aggregate kind `30023` content byte lengths and author distinct state by day plus all-time. | `longform_daily` and/or `longform_all_time`. | Rust/ClickHouse/DuckDB string length semantics must be tested with non-ASCII content. Preserve the existing byte/character behavior only after fixtures identify it. |
+| `GET /api/v1/stats/relays/distribution` | `limit` default 100/max 1000. Reads a six-hour refresh of each pubkey's latest kind `10002`, normalizes `wss://` relay URLs, interprets read/write markers, filters invalid URLs and counts below 10. | Select the latest canonical kind `10002` per pubkey with deterministic tie-breaking, unnest tags, reproduce URL normalization and mode rules, and aggregate. | `relay_distribution_current`. | This is current-state replacement semantics, not an additive event rollup. The exact normalization/filter contract lives in migration 014 and needs shared fixtures. |
+
+## 7. Routes that do not move through DuckDB
+
+The following remain backed by the ingester's operational relay database during
+the first analytics migration:
+
+- `GET /api/v1/relays/summary`;
+- `GET /api/v1/relays`;
+- `GET /api/v1/relays/throughput`.
+
+They describe relay discovery, connection state, scores, events received, and
+novel events observed by this Pensieve instance. Those facts are not derivable
+from canonical Nostr event Parquet. Moving them to Postgres would be a separate
+operational-database replication decision, not part of ClickHouse retirement.
+
+`/health`, `/docs`, and `/api/v1/ping` likewise require no analytical migration.
+
+## 8. Initial product table families
+
+The endpoint ledger currently implies these logical products:
+
+| Product | Grain / key | Consumers |
+|---|---|---|
+| Analytics run catalog | `run_id`, active snapshot ID | every endpoint and verifier |
+| Overview | one row per run | overview and scalar stats |
+| Pubkey first seen | `pubkey` | total pubkeys, new users, retention |
+| Event activity | day/hour, optional kind | events, throughput, kinds, hourly activity |
+| Kind all-time | kind | kinds list/detail |
+| Active users | grain + period | active-user summary and series |
+| Cohort retention | grain + cohort + activity period | retention |
+| Zap facts/rollups | day + optional bucket | zap totals and histogram |
+| Engagement | day | engagement |
+| Long-form | day/all-time | long-form |
+| Publisher activity | day + pubkey + optional kind, design pending | publishers |
+| Relay distribution | current relay URL | NIP-65 distribution |
+
+This is a logical inventory, not permission to create all tables immediately.
+In particular, publisher activity and query-time distinct-state storage require
+size measurements before DDL is accepted.
+
+## 9. Build and verification order
+
+### Slice A — additive and scalar
+
+Implemented in the first shadow builder:
+
+1. [x] analytics run catalog and atomic publication;
+2. [x] total logical events;
+3. [x] earliest/latest event;
+4. [x] daily event counts and seven-day throughput; and
+5. [x] all-time and daily kind counts.
+
+This slice establishes catalog consumption, deduplication, time filtering,
+late-event updates, Postgres publication, and the old/new comparison harness
+without sketch or nested-tag dependencies.
+
+The implementation and operator procedure are in
+[`analytics_slice_a.md`](analytics_slice_a.md). Completion here means the
+builder, versioned serving DDL, atomic pointer, and local exactness fixtures
+exist. It does not mean production shadow deployment, ClickHouse parity,
+endpoint cutover, or acceptance of the provisional time semantics.
+
+### Slice B — identity and distinct state
+
+1. eligible pubkey first seen;
+2. total and new pubkeys;
+3. event/kind unique pubkeys;
+4. active users; and
+5. cohort retention.
+
+This slice selects and validates exact-versus-sketch behavior.
+
+### Slice C — semantic transformations
+
+1. engagement tag classification;
+2. long-form byte-length rules;
+3. zap parsing and buckets; and
+4. latest NIP-65 relay-list reduction.
+
+### Slice D — high-cardinality serving
+
+1. publisher ranking storage/compute benchmark;
+2. bounded-window and arbitrary-window correctness proof; and
+3. final endpoint implementation if the measured relation is acceptable.
+
+## 10. Comparison harness
+
+The harness sends the same authenticated request to the ClickHouse-backed and
+Postgres-backed implementations and compares normalized JSON plus metadata.
+
+At minimum it must cover:
+
+- empty data and one-event fixtures;
+- duplicate event IDs in different files;
+- two valid signatures for one event ID;
+- late-arriving historical events;
+- future timestamps, pre-genesis timestamps, `u32::MAX`, and larger unsigned
+  timestamps;
+- ASCII and multi-byte `content`;
+- one-element and multi-element tags;
+- excluded kinds `445` and `1059`;
+- all supported day/week/month boundaries;
+- DST-independent UTC calculations;
+- default, minimum, maximum, and invalid query parameters;
+- no-group and grouped dynamic response shapes;
+- top-K ties and deterministic ordering;
+- zero-denominator percentages; and
+- a production request matrix sampled from actual dashboard traffic.
+
+For approximate fields the harness records absolute difference, relative
+difference, configured tolerance, and repeatability across rebuilds. Exact
+fields compare bit-for-bit after the documented old-stack divergence rules.
+
+Every result row must identify:
+
+- endpoint and normalized parameters;
+- ClickHouse observation time;
+- Postgres analytics run and snapshot IDs;
+- ClickHouse and Postgres data freshness;
+- comparison classification; and
+- linked expected-divergence entry, when applicable.
+
+## 11. Decisions required before cutover
+
+1. Is `/stats/events/latest` required to remain meaningfully fresher than the
+   maximum Parquet batch age? If yes, select the live-delta source.
+2. Does the public contract follow current future-timestamp behavior endpoint
+   by endpoint, or adopt one consistent `created_at <= as_of` rule?
+3. Which distinct metrics must remain exact?
+4. Should serialized sketches ever be merged by Postgres, or only by the
+   analytics builder?
+5. Is the current retention cohort ordering a bug to fix?
+6. Is the publisher endpoint important enough to justify a high-cardinality
+   serving relation, or can its supported windows be narrowed?
+7. Should database/query failures continue returning zero in the overview?
+8. What freshness objectives apply to each endpoint family independently of
+   response-cache TTL?
+
+These decisions should be made from the first comparison runs and relation-size
+benchmarks, not from DDL speculation.

--- a/docs/analytics_slice_a.md
+++ b/docs/analytics_slice_a.md
@@ -1,0 +1,120 @@
+# Analytics Slice A — Builder and Publication Runbook
+
+*Status: implemented for local/shadow validation; not accepted for API cutover*
+*Last updated: 2026-07-28*
+
+This is the first executable DuckDB/Postgres analytics slice described by the
+[analytics endpoint migration ledger](analytics_endpoint_migration.md). It
+does not change `pensieve-serve`, Grafana, ClickHouse, ingestion, or the
+canonical Parquet lake.
+
+## What it builds
+
+`pensieve-analytics` consumes one explicitly selected, canonically encoded
+active-raw snapshot. It resolves the snapshot's immutable object keys, scans
+only `id`, `created_at`, `kind`, and `sig`, and materializes one deterministic
+event row per ID in a persistent DuckDB work database. When an ID occurs more
+than once, the lexicographically smallest raw signature wins, matching the
+canonical V1 rule.
+
+One full rebuild creates:
+
+- `rollup_overview`: logical total, API-domain total, earliest/latest event,
+  rolling seven-day count/rate, and rolling 30-day kind count;
+- `rollup_event_daily`: exact logical event counts by UTC date;
+- `rollup_event_daily_kind`: exact logical counts by UTC date and kind; and
+- `rollup_kind_all_time`: exact logical counts by kind.
+
+The build fails before publication unless:
+
+- the catalog's physical row total is at least the deduplicated logical total;
+- both daily products sum to the API-representable logical total; and
+- all-time kind counts sum to the complete logical total.
+
+This first version is deliberately a full rebuild. Late historical events are
+therefore placed into their correct historical day automatically. Incremental
+and affected-period rebuild modes remain future work.
+
+## Frozen Slice A time semantics
+
+These rules are versioned as `slice-a-v1` and are candidates for shadow
+comparison, not yet a public API acceptance decision:
+
+- `total_events` and all-time kind counts cover every logical event in the full
+  unsigned `created_at` domain, including future and API-unrepresentable rows;
+- daily products include `created_at <= u32::MAX` and use UTC epoch-day
+  boundaries, including representable future dates;
+- earliest event uses that representable domain and retains the existing Nostr
+  genesis clamp;
+- latest event includes only `created_at <= as_of`;
+- seven-day throughput is the inclusive interval
+  `[as_of - 604800, as_of]`, capped at `as_of`, divided by exactly 168; and
+- rolling 30-day kind count is likewise capped at `as_of`.
+
+Every comparison result must still classify differences from ClickHouse,
+especially its inconsistent future-event behavior.
+
+## Build-only canary
+
+Use a fixed `as_of` value so the run is reproducible:
+
+```bash
+just analytics-build \
+  --catalog /var/lib/pensieve-parquet/catalog/active-raw.json \
+  --work-database /var/lib/pensieve-analytics/slice-a.duckdb \
+  --as-of 1785232800
+```
+
+Omitting `DATABASE_URL` builds and validates DuckDB products without touching
+Postgres. The command prints one JSON summary suitable for a run log.
+
+For local/offline fixtures or a locally mounted immutable lake, add:
+
+```bash
+--local-object-root /path/to/lake
+```
+
+Without that override, the snapshot `store_id` must have the form
+`s3+https://<endpoint>/<bucket>`. Object keys become `s3://` URIs. DuckDB loads
+its signed `httpfs` and `aws` extensions and obtains credentials only through
+the standard AWS environment credential chain. The first S3 run therefore
+needs extension-repository network access; later runs use DuckDB's local
+extension cache.
+
+## Shadow Postgres publication
+
+Install a private environment file based on `ops/analytics.env.example`, set
+the deployed Git commit as `PENSIEVE_ANALYTICS_CODE_VERSION`, and run the same
+command with `DATABASE_URL` present.
+
+The binary idempotently applies
+`docs/postgres/001_analytics_slice_a.sql`, then opens one Postgres transaction.
+It:
+
+1. takes a transaction-scoped advisory publication lock;
+2. records the snapshot, prior run, code/query versions, fixed `as_of`, input
+   object keys/checksums, row counts, and validation result;
+3. streams the four products into run-keyed serving tables with `COPY`;
+4. changes the singleton `current_run` pointer; and
+5. commits everything together.
+
+Readers use the `pensieve_analytics.current_*` views. They see either the
+previous complete run or the next complete run, never a mixture. Retrying the
+same deterministic run while it remains current is a no-op. Attempting to make
+an older already-published run current again is rejected.
+
+The current client uses a non-TLS Postgres connection. Deploy it against a
+colocated Unix socket or trusted localhost. Remote Postgres TLS support must be
+added before any networked deployment.
+
+## Shadow gate before API work
+
+Do not point `pensieve-serve` or Grafana at these views yet. The next gate is:
+
+1. build from a small catalog fixture and inspect all relations;
+2. build from a real bounded active-file snapshot;
+3. publish twice to prove idempotency and atomic pointer movement;
+4. compare Slice A endpoint results against ClickHouse with a fixed `as_of`;
+5. measure DuckDB work-database size, peak memory, S3 bytes read, build time,
+   Postgres relation sizes, and publication time; and
+6. record every old/new difference using the ledger classifications.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -2,7 +2,7 @@
 
 *Status: active / executing*
 *Created: 2026-06-14*
-*Last updated: 2026-07-23*
+*Last updated: 2026-07-28*
 *Owner: Jeff*
 
 This is the canonical execution plan for migrating Pensieve from its current stack
@@ -19,7 +19,7 @@ It is a companion to the target-architecture design notes. Where the design doc 
 ```
 relay collectors ─► RocksDB dedup ─► notepack .gz segments (source of truth)
                                           └─► ClickHouse (events_local + ~7 MVs)
-                                                 ├─► pensieve-serve (32 analytics endpoints)
+                                                 ├─► pensieve-serve (24 ClickHouse-backed analytics routes)
                                                  └─► pensieve-preview (per-event pages) ← being dropped
 ```
 
@@ -28,8 +28,9 @@ relay collectors ─► RocksDB dedup ─► notepack .gz segments (source of tr
   (`github.com/erskingardner/notepack`) — durability risk over a 10-year horizon.
 - **Analytics:** ClickHouse, ~2.6 TiB on NVMe and growing. Already pre-aggregates via
   materialized views (DAU/WAU/MAU, first-seen, zaps, kinds, relay distribution).
-- **Serving:** `pensieve-serve` (real, 32 endpoints — *not* a placeholder) +
-  `pensieve-preview` (random-access-by-id event pages).
+- **Serving:** `pensieve-serve` (30 GET routes: 24 ClickHouse-backed analytics,
+  3 relay-operational SQLite routes, authenticated ping, and 2 public service
+  routes) + `pensieve-preview` (random-access-by-id event pages).
 - **Dedup:** RocksDB, ~50 GB at 1.4 B events. It currently filters the global
   ingest stream and participates in archive state transitions. It is retained
   during migration, but the target archive must remain correct if this
@@ -581,8 +582,21 @@ shadow-only; authoritative notepack ingestion is unaffected.
 
 ### P3 — Optimize the lake and build analytics in parallel  *(Track B)*
 
+- [x] Freeze the current analytics surface in the
+      [endpoint migration ledger](analytics_endpoint_migration.md): 24
+      ClickHouse-backed routes plus the separately scoped relay-operational and
+      service routes. The ledger records request/response contracts, current
+      query semantics, proposed DuckDB products, candidate Postgres serving
+      shapes, parity classifications, and the initial implementation order.
+- [x] Implement the first shadow analytics slice: active-snapshot consumption,
+      exact cross-file ID deduplication, overview/daily/kind DuckDB products,
+      reconciliations, versioned Postgres serving DDL, input/run provenance,
+      streamed publication, and an atomic current-run pointer. See
+      [Analytics Slice A](analytics_slice_a.md). This is not yet deployed,
+      parity-approved, or connected to the API.
 - [ ] Stand up **Postgres** rollup store.
-- [ ] **DuckDB batch jobs** reproducing all 32 endpoints' metrics from Parquet.
+- [ ] **DuckDB batch jobs** reproducing all 24 ClickHouse-backed analytics
+      routes' metrics from Parquet.
       Distinct/rolling metrics use **Apache DataSketches HLL end-to-end**: DuckDB's
       built-in `approx_count_distinct` exposes no mergeable sketch state, and
       `postgresql-hll`'s binary format is **incompatible** with DataSketches — so it's
@@ -789,7 +803,11 @@ Updated 2026-07-28.
   targeted historical content comparison, coordinated go-forward parity
   windows, publication fault coverage, and the post-P5 unsealed-buffer
   failure-domain proof remain.
-- **P3 Optimization + new analytics** — not started
+- **P3 Optimization + new analytics** — implementation started. The current
+  ClickHouse-backed API surface and endpoint-by-endpoint parity contract are
+  inventoried. Slice A now has an executable DuckDB builder and transactional
+  Postgres serving schema; real-snapshot shadow deployment, old/new comparison,
+  later slices, endpoint cutover, and the optimizer remain.
 - **P4 Reader cutover** — not started
 - **P5 Parquet durability authority** — not started
 - **P6 Retire old storage** — not started
@@ -800,6 +818,8 @@ secrets in `/etc/pensieve/pensieve.env`; production box cut over to the new layo
 ---
 
 ## Related
+- `docs/analytics_endpoint_migration.md` — draft endpoint contract, DuckDB
+  product mapping, Postgres serving candidates, and parity ledger for P3
 - `docs/parquet_archive_format.md` — accepted canonical V1 specification
 - `docs/lake_active_file_catalog.md` — deterministic distributed-inventory
   export, merge, verification, and immutable snapshot publication

--- a/docs/postgres/001_analytics_slice_a.sql
+++ b/docs/postgres/001_analytics_slice_a.sql
@@ -1,0 +1,133 @@
+-- Migration: 001_analytics_slice_a
+-- Description: Versioned serving relations and atomic run pointer for the
+--              first DuckDB/Postgres analytics slice.
+-- Date: 2026-07-28
+--
+-- This schema is rebuildable from a selected active-file snapshot. The batch
+-- builder applies this idempotently before transactional publication.
+
+CREATE SCHEMA IF NOT EXISTS pensieve_analytics;
+
+CREATE TABLE IF NOT EXISTS pensieve_analytics.runs (
+    run_id TEXT PRIMARY KEY,
+    snapshot_id TEXT NOT NULL,
+    previous_run_id TEXT REFERENCES pensieve_analytics.runs (run_id),
+    run_kind TEXT NOT NULL CHECK (run_kind IN (
+        'full_rebuild',
+        'affected_period_rebuild',
+        'incremental'
+    )),
+    query_version TEXT NOT NULL,
+    code_version TEXT NOT NULL,
+    as_of_epoch BIGINT NOT NULL CHECK (
+        as_of_epoch >= 0 AND as_of_epoch <= 4294967295
+    ),
+    started_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ NOT NULL,
+    published_at TIMESTAMPTZ NOT NULL,
+    physical_rows BIGINT NOT NULL CHECK (physical_rows >= 0),
+    logical_events BIGINT NOT NULL CHECK (logical_events >= 0),
+    duplicate_rows BIGINT NOT NULL CHECK (duplicate_rows >= 0),
+    api_representable_events BIGINT NOT NULL CHECK (
+        api_representable_events >= 0
+    ),
+    event_daily_rows BIGINT NOT NULL CHECK (event_daily_rows >= 0),
+    event_daily_kind_rows BIGINT NOT NULL CHECK (
+        event_daily_kind_rows >= 0
+    ),
+    kind_all_time_rows BIGINT NOT NULL CHECK (kind_all_time_rows >= 0),
+    validation JSONB NOT NULL,
+    CHECK (completed_at >= started_at),
+    CHECK (physical_rows = logical_events + duplicate_rows)
+);
+
+CREATE TABLE IF NOT EXISTS pensieve_analytics.run_inputs (
+    run_id TEXT NOT NULL REFERENCES pensieve_analytics.runs (run_id)
+        ON DELETE CASCADE,
+    object_key TEXT NOT NULL,
+    work_unit_id TEXT NOT NULL,
+    sha256 TEXT NOT NULL CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+    byte_size BIGINT NOT NULL CHECK (byte_size >= 0),
+    physical_rows BIGINT NOT NULL CHECK (physical_rows >= 0),
+    PRIMARY KEY (run_id, object_key)
+);
+
+CREATE TABLE IF NOT EXISTS pensieve_analytics.overview (
+    run_id TEXT PRIMARY KEY REFERENCES pensieve_analytics.runs (run_id)
+        ON DELETE CASCADE,
+    total_events BIGINT NOT NULL CHECK (total_events >= 0),
+    api_representable_events BIGINT NOT NULL CHECK (
+        api_representable_events >= 0
+    ),
+    earliest_event BIGINT NOT NULL CHECK (
+        earliest_event >= 0 AND earliest_event <= 4294967295
+    ),
+    latest_event BIGINT NOT NULL CHECK (
+        latest_event >= 0 AND latest_event <= 4294967295
+    ),
+    events_7d BIGINT NOT NULL CHECK (events_7d >= 0),
+    events_per_hour_7d DOUBLE PRECISION NOT NULL CHECK (
+        events_per_hour_7d >= 0
+    ),
+    kinds_30d BIGINT NOT NULL CHECK (kinds_30d >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS pensieve_analytics.event_daily (
+    run_id TEXT NOT NULL REFERENCES pensieve_analytics.runs (run_id)
+        ON DELETE CASCADE,
+    day DATE NOT NULL,
+    event_count BIGINT NOT NULL CHECK (event_count >= 0),
+    PRIMARY KEY (run_id, day)
+);
+
+CREATE TABLE IF NOT EXISTS pensieve_analytics.event_daily_kind (
+    run_id TEXT NOT NULL REFERENCES pensieve_analytics.runs (run_id)
+        ON DELETE CASCADE,
+    day DATE NOT NULL,
+    kind INTEGER NOT NULL CHECK (kind >= 0 AND kind <= 65535),
+    event_count BIGINT NOT NULL CHECK (event_count >= 0),
+    PRIMARY KEY (run_id, day, kind)
+);
+
+CREATE TABLE IF NOT EXISTS pensieve_analytics.kind_all_time (
+    run_id TEXT NOT NULL REFERENCES pensieve_analytics.runs (run_id)
+        ON DELETE CASCADE,
+    kind INTEGER NOT NULL CHECK (kind >= 0 AND kind <= 65535),
+    event_count BIGINT NOT NULL CHECK (event_count >= 0),
+    PRIMARY KEY (run_id, kind)
+);
+
+CREATE TABLE IF NOT EXISTS pensieve_analytics.current_run (
+    singleton BOOLEAN PRIMARY KEY CHECK (singleton),
+    run_id TEXT NOT NULL REFERENCES pensieve_analytics.runs (run_id)
+);
+
+CREATE OR REPLACE VIEW pensieve_analytics.current_run_metadata AS
+SELECT run.*
+FROM pensieve_analytics.current_run current
+JOIN pensieve_analytics.runs run USING (run_id)
+WHERE current.singleton;
+
+CREATE OR REPLACE VIEW pensieve_analytics.current_overview AS
+SELECT overview.*
+FROM pensieve_analytics.current_run current
+JOIN pensieve_analytics.overview overview USING (run_id)
+WHERE current.singleton;
+
+CREATE OR REPLACE VIEW pensieve_analytics.current_event_daily AS
+SELECT event_daily.*
+FROM pensieve_analytics.current_run current
+JOIN pensieve_analytics.event_daily event_daily USING (run_id)
+WHERE current.singleton;
+
+CREATE OR REPLACE VIEW pensieve_analytics.current_event_daily_kind AS
+SELECT event_daily_kind.*
+FROM pensieve_analytics.current_run current
+JOIN pensieve_analytics.event_daily_kind event_daily_kind USING (run_id)
+WHERE current.singleton;
+
+CREATE OR REPLACE VIEW pensieve_analytics.current_kind_all_time AS
+SELECT kind_all_time.*
+FROM pensieve_analytics.current_run current
+JOIN pensieve_analytics.kind_all_time kind_all_time USING (run_id)
+WHERE current.singleton;

--- a/justfile
+++ b/justfile
@@ -57,6 +57,10 @@ source-manifest *ARGS:
 lake-catalog *ARGS:
     cargo run -p pensieve-lake --bin pensieve-lake-catalog -- {{ARGS}}
 
+# Build and optionally publish exact Slice A analytics.
+analytics-build *ARGS:
+    cargo run -p pensieve-analytics -- {{ARGS}}
+
 # ============================================================================
 # Build
 # ============================================================================

--- a/ops/analytics.env.example
+++ b/ops/analytics.env.example
@@ -1,0 +1,18 @@
+# DuckDB-to-Postgres analytics builder configuration.
+#
+# Install outside the repository with mode 0600. The Slice A binary is a batch
+# process, not a long-running service. Keep the fixed --catalog,
+# --work-database, and --as-of arguments in the invoking job or run record.
+
+# A colocated Postgres connection is expected for Slice A. The current client
+# deliberately uses NoTls, so do not point this at an untrusted network.
+DATABASE_URL=host=/var/run/postgresql dbname=pensieve user=pensieve
+
+# Standard AWS credential-chain names consumed by DuckDB. The non-secret
+# endpoint and bucket come from the active-file snapshot's store_id.
+AWS_ACCESS_KEY_ID=replace-me
+AWS_SECRET_ACCESS_KEY=replace-me
+AWS_REGION=hel1
+
+# Set this to the deployed Git commit (or another immutable build identity).
+PENSIEVE_ANALYTICS_CODE_VERSION=replace-with-git-commit


### PR DESCRIPTION
## Summary

- freeze the current 24-route ClickHouse analytics contract and migration order
- add the first exact DuckDB analytics builder over an explicit active-file snapshot
- deduplicate cross-file event IDs and build overview, daily event, daily-kind, and all-time kind products
- add versioned Postgres serving relations with run/input provenance and atomic current-run publication
- add build-only and local-object modes, an operator runbook, and environment template

## Why

Pensieve needs a rebuildable shadow analytics path before ClickHouse can be retired. This slice establishes the catalog, computation, validation, and publication boundaries without changing `pensieve-serve`, Grafana, ingestion, or the canonical Parquet lake.

The time semantics are versioned as provisional `slice-a-v1` behavior for old/new comparison. This PR does not approve API cutover or deploy Postgres.

## Validation

- `just precommit`
- exact local fixtures covering cross-file duplicates, pre-genesis timestamps, future timestamps, `u32::MAX + 1`, rolling-window boundaries, and an empty active snapshot
- disposable Postgres 17 round trip covering schema creation, bulk publication, reads through current views, and idempotent retry
